### PR TITLE
Add ParsePortRange and PartParse from docker/docker/pkg/parsers

### DIFF
--- a/nat/nat.go
+++ b/nat/nat.go
@@ -6,8 +6,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-
-	"github.com/docker/docker/pkg/parsers"
 )
 
 const (
@@ -37,7 +35,7 @@ func NewPort(proto, port string) (Port, error) {
 	// Check for parsing issues on "port" now so we can avoid having
 	// to check it later on.
 
-	portStartInt, portEndInt, err := ParsePortRange(port)
+	portStartInt, portEndInt, err := ParsePortRangeToInt(port)
 	if err != nil {
 		return "", err
 	}
@@ -60,12 +58,12 @@ func ParsePort(rawPort string) (int, error) {
 	return int(port), nil
 }
 
-// ParsePortRange parses the port range string and returns start/end ints
-func ParsePortRange(rawPort string) (int, int, error) {
+// ParsePortRangeToInt parses the port range string and returns start/end ints
+func ParsePortRangeToInt(rawPort string) (int, int, error) {
 	if len(rawPort) == 0 {
 		return 0, 0, nil
 	}
-	start, end, err := parsers.ParsePortRange(rawPort)
+	start, end, err := ParsePortRange(rawPort)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -99,7 +97,7 @@ func (p Port) Int() int {
 
 // Range returns the start/end port numbers of a Port range as ints
 func (p Port) Range() (int, int, error) {
-	return ParsePortRange(p.Port())
+	return ParsePortRangeToInt(p.Port())
 }
 
 // SplitProtoPort splits a port in the format of proto/port
@@ -148,7 +146,7 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 			rawPort = fmt.Sprintf(":%s", rawPort)
 		}
 
-		parts, err := parsers.PartParser(portSpecTemplate, rawPort)
+		parts, err := PartParser(portSpecTemplate, rawPort)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -166,14 +164,14 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 			return nil, nil, fmt.Errorf("No port specified: %s<empty>", rawPort)
 		}
 
-		startPort, endPort, err := parsers.ParsePortRange(containerPort)
+		startPort, endPort, err := ParsePortRange(containerPort)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Invalid containerPort: %s", containerPort)
 		}
 
 		var startHostPort, endHostPort uint64 = 0, 0
 		if len(hostPort) > 0 {
-			startHostPort, endHostPort, err = parsers.ParsePortRange(hostPort)
+			startHostPort, endHostPort, err = ParsePortRange(hostPort)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Invalid hostPort: %s", hostPort)
 			}

--- a/nat/nat_test.go
+++ b/nat/nat_test.go
@@ -41,7 +41,7 @@ func TestParsePort(t *testing.T) {
 	}
 }
 
-func TestParsePortRange(t *testing.T) {
+func TestParsePortRangeToInt(t *testing.T) {
 	var (
 		begin int
 		end   int
@@ -63,7 +63,7 @@ func TestParsePortRange(t *testing.T) {
 	}
 
 	for _, r := range validRanges {
-		begin, end, err = ParsePortRange(r.Range)
+		begin, end, err = ParsePortRangeToInt(r.Range)
 
 		if err != nil || begin != r.Begin {
 			t.Fatalf("Parsing port range '%s' did not succeed. Expected begin %d, got %d", r.Range, r.Begin, begin)
@@ -83,7 +83,7 @@ func TestParsePortRange(t *testing.T) {
 	}
 
 	for _, r := range invalidRanges {
-		begin, end, err = ParsePortRange(r)
+		begin, end, err = ParsePortRangeToInt(r)
 
 		if err == nil || begin != 0 || end != 0 {
 			t.Fatalf("Parsing port range '%s' succeeded", r)

--- a/nat/parse.go
+++ b/nat/parse.go
@@ -1,0 +1,56 @@
+package nat
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// PartParser parses and validates the specified string (data) using the specified template
+// e.g. ip:public:private -> 192.168.0.1:80:8000
+func PartParser(template, data string) (map[string]string, error) {
+	// ip:public:private
+	var (
+		templateParts = strings.Split(template, ":")
+		parts         = strings.Split(data, ":")
+		out           = make(map[string]string, len(templateParts))
+	)
+	if len(parts) != len(templateParts) {
+		return nil, fmt.Errorf("Invalid format to parse. %s should match template %s", data, template)
+	}
+
+	for i, t := range templateParts {
+		value := ""
+		if len(parts) > i {
+			value = parts[i]
+		}
+		out[t] = value
+	}
+	return out, nil
+}
+
+// ParsePortRange parses and validates the specified string as a port-range (8000-9000)
+func ParsePortRange(ports string) (uint64, uint64, error) {
+	if ports == "" {
+		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+	}
+	if !strings.Contains(ports, "-") {
+		start, err := strconv.ParseUint(ports, 10, 16)
+		end := start
+		return start, end, err
+	}
+
+	parts := strings.Split(ports, "-")
+	start, err := strconv.ParseUint(parts[0], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return 0, 0, err
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("Invalid range specified for the Port: %s", ports)
+	}
+	return start, end, nil
+}

--- a/nat/parse_test.go
+++ b/nat/parse_test.go
@@ -1,0 +1,54 @@
+package nat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePortRange(t *testing.T) {
+	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
+		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
+	}
+}
+
+func TestParsePortRangeEmpty(t *testing.T) {
+	if _, _, err := ParsePortRange(""); err == nil || err.Error() != "Empty string specified for ports." {
+		t.Fatalf("Expected error 'Empty string specified for ports.', got %v", err)
+	}
+}
+
+func TestParsePortRangeWithNoRange(t *testing.T) {
+	start, end, err := ParsePortRange("8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start != 8080 || end != 8080 {
+		t.Fatalf("Expected start and end to be the same and equal to 8080, but were %v and %v", start, end)
+	}
+}
+
+func TestParsePortRangeIncorrectRange(t *testing.T) {
+	if _, _, err := ParsePortRange("9000-8080"); err == nil || !strings.Contains(err.Error(), "Invalid range specified for the Port") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectEndRange(t *testing.T) {
+	if _, _, err := ParsePortRange("8000-a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("8000-30a"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}
+
+func TestParsePortRangeIncorrectStartRange(t *testing.T) {
+	if _, _, err := ParsePortRange("a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+
+	if _, _, err := ParsePortRange("30a-8000"); err == nil || !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Expecting error 'Invalid range specified for the Port' but received %s.", err)
+	}
+}

--- a/nat/sort.go
+++ b/nat/sort.go
@@ -3,8 +3,6 @@ package nat
 import (
 	"sort"
 	"strings"
-
-	"github.com/docker/docker/pkg/parsers"
 )
 
 type portSorter struct {
@@ -90,7 +88,7 @@ func SortPortMap(ports []Port, bindings PortMap) {
 }
 
 func toInt(s string) uint64 {
-	i, _, err := parsers.ParsePortRange(s)
+	i, _, err := ParsePortRange(s)
 	if err != nil {
 		i = 0
 	}


### PR DESCRIPTION
`PartParse` is only used by this package
`ParsePortRange` is only used by one other package, which already depends on `nat`
They can both be removed from docker/docker.

This removes the direct dependency on docker/docker, however there is still a transitive dependency from opencontainer/runc