### PR TITLE
Swap CloseRead and CloseWrite

### DIFF
--- a/proxy/tcp_proxy.go
+++ b/proxy/tcp_proxy.go
@@ -46,10 +46,10 @@ func (proxy *TCPProxy) clientLoop(client *net.TCPConn, quit chan bool) {
 			// If the socket we are writing to is shutdown with
 			// SHUT_WR, forward it to the other end of the pipe:
 			if err, ok := err.(*net.OpError); ok && err.Err == syscall.EPIPE {
-				from.CloseWrite()
+				from.CloseRead()
 			}
 		}
-		to.CloseRead()
+		to.CloseWrite()
 		event <- written
 	}
 


### PR DESCRIPTION
To notify the other end of a connection that no writes are going to happen anymore, CloseWrite() should be used.

Signed-off-by: Andre Luiz dos Santos andre.netvision.com.br@gmail.com
