### PR TITLE
Build sockets/unix_socket.go for Solaris

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -1,4 +1,4 @@
-// +build linux freebsd
+// +build linux freebsd solaris
 
 package sockets
 


### PR DESCRIPTION
Docker uses the methods from the github.com/docker/go-connections/sockets package to connect to unix sockets.
This PR enables this on Solaris. This has been tested and works on Solaris
This is a part of a larger effort for a native port of Docker on Solaris.

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>