### PR TITLE
Parse raw certificate subjects before debug logging

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -72,12 +72,7 @@ func certPool(caFile string) (*x509.CertPool, error) {
 	if !certPool.AppendCertsFromPEM(pem) {
 		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)
 	}
-	s := certPool.Subjects()
-	subjects := make([]string, len(s))
-	for i, subject := range s {
-		subjects[i] = string(subject)
-	}
-	logrus.Debugf("Trusting certs with subjects: %v", subjects)
+	logrus.Debugf("Trusting %d certs", len(certPool.Subjects()))
 	return certPool, nil
 }
 


### PR DESCRIPTION
When initializing the certificate pool, it would be helpful to print the parsed `pkix.Name` to debug logs instead of the raw DER bytes (example of previous output here: https://github.com/docker/notary/issues/611)

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>