### PR TITLE
Add function to get system cert pool

### DIFF
--- a/tlsconfig/certpool_go17.go
+++ b/tlsconfig/certpool_go17.go
@@ -1,0 +1,21 @@
+// +build go1.7
+
+package tlsconfig
+
+import (
+	"crypto/x509"
+	"runtime"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// SystemCertPool returns a copy of the system cert pool,
+// returns an error if failed to load or empty pool on windows.
+func SystemCertPool() (*x509.CertPool, error) {
+	certpool, err := x509.SystemCertPool()
+	if err != nil && runtime.GOOS == "windows" {
+		logrus.Warnf("Unable to use system certificate pool: %v", err)
+		return x509.NewCertPool(), nil
+	}
+	return certpool, err
+}

--- a/tlsconfig/certpool_other.go
+++ b/tlsconfig/certpool_other.go
@@ -1,0 +1,16 @@
+// +build !go1.7
+
+package tlsconfig
+
+import (
+	"crypto/x509"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// SystemCertPool returns an new empty cert pool,
+// accessing system cert pool is supported in go 1.7
+func SystemCertPool() (*x509.CertPool, error) {
+	logrus.Warn("Unable to use system certificate pool: requires building with go 1.7 or later")
+	return x509.NewCertPool(), nil
+}

--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -68,10 +68,13 @@ func ClientDefault() *tls.Config {
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
 func certPool(caFile string) (*x509.CertPool, error) {
 	// If we should verify the server, we need to load a trusted ca
-	certPool := x509.NewCertPool()
+	certPool, err := SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read system certificates: %v", err)
+	}
 	pem, err := ioutil.ReadFile(caFile)
 	if err != nil {
-		return nil, fmt.Errorf("Could not read CA certificate %q: %v", caFile, err)
+		return nil, fmt.Errorf("could not read CA certificate %q: %v", caFile, err)
 	}
 	if !certPool.AppendCertsFromPEM(pem) {
 		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)


### PR DESCRIPTION
Defaults to getting empty cert pool when less than go 1.7 or fails to load the system cert pool.

Needed for https://github.com/docker/docker/issues/12756
