### PR TITLE
Use meaningful error message if unix socket path is too long

### DIFF
--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -3,10 +3,30 @@
 package sockets
 
 import (
+	"fmt"
 	"net"
+	"net/http"
 	"syscall"
 	"time"
 )
+
+const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
+
+func configureUnixTransport(tr *http.Transport, proto, addr string) error {
+	if len(addr) > maxUnixSocketPathSize {
+		return fmt.Errorf("Unix socket path %q is too long", addr)
+	}
+	// No need for compression in local communications.
+	tr.DisableCompression = true
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return net.DialTimeout(proto, addr, defaultTimeout)
+	}
+	return nil
+}
+
+func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
+	return ErrProtocolNotAvailable
+}
 
 // DialPipe connects to a Windows named pipe.
 // This is not supported on other OSes.

--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -2,10 +2,24 @@ package sockets
 
 import (
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/Microsoft/go-winio"
 )
+
+func configureUnixTransport(tr *http.Transport, proto, addr string) error {
+	return ErrProtocolNotAvailable
+}
+
+func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
+	// No need for compression in local communications.
+	tr.DisableCompression = true
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return DialPipe(addr, defaultTimeout)
+	}
+	return nil
+}
 
 // DialPipe connects to a Windows named pipe.
 func DialPipe(addr string, timeout time.Duration) (net.Conn, error) {


### PR DESCRIPTION
Signed-off-by: Tibor Vass <teabee89@gmail.com>