### PR TITLE
Remove support for group lookup

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -1,31 +1,26 @@
-// +build linux freebsd solaris
+// +build !windows
 
 package sockets
 
 import (
-	"fmt"
 	"net"
 	"os"
-	"strconv"
 	"syscall"
-
-	"github.com/Sirupsen/logrus"
-	"github.com/opencontainers/runc/libcontainer/user"
 )
 
 // NewUnixSocket creates a unix socket with the specified path and group.
-func NewUnixSocket(path, group string) (net.Listener, error) {
+func NewUnixSocket(path string, gid int) (net.Listener, error) {
 	if err := syscall.Unlink(path); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	mask := syscall.Umask(0777)
 	defer syscall.Umask(mask)
+
 	l, err := net.Listen("unix", path)
 	if err != nil {
 		return nil, err
 	}
-	if err := setSocketGroup(path, group); err != nil {
-		l.Close()
+	if err := os.Chown(path, 0, gid); err != nil {
 		return nil, err
 	}
 	if err := os.Chmod(path, 0660); err != nil {
@@ -33,48 +28,4 @@ func NewUnixSocket(path, group string) (net.Listener, error) {
 		return nil, err
 	}
 	return l, nil
-}
-
-func setSocketGroup(path, group string) error {
-	if group == "" {
-		return nil
-	}
-	if err := changeGroup(path, group); err != nil {
-		if group != "docker" {
-			return err
-		}
-		logrus.Debugf("Warning: could not change group %s to docker: %v", path, err)
-	}
-	return nil
-}
-
-func changeGroup(path string, nameOrGid string) error {
-	gid, err := lookupGidByName(nameOrGid)
-	if err != nil {
-		return err
-	}
-	logrus.Debugf("%s group found. gid: %d", nameOrGid, gid)
-	return os.Chown(path, 0, gid)
-}
-
-func lookupGidByName(nameOrGid string) (int, error) {
-	groupFile, err := user.GetGroupPath()
-	if err != nil {
-		return -1, err
-	}
-	groups, err := user.ParseGroupFileFilter(groupFile, func(g user.Group) bool {
-		return g.Name == nameOrGid || strconv.Itoa(g.Gid) == nameOrGid
-	})
-	if err != nil {
-		return -1, err
-	}
-	if groups != nil && len(groups) > 0 {
-		return groups[0].Gid, nil
-	}
-	gid, err := strconv.Atoi(nameOrGid)
-	if err == nil {
-		logrus.Warnf("Could not find GID %d", gid)
-		return gid, nil
-	}
-	return -1, fmt.Errorf("Group %s not found", nameOrGid)
 }


### PR DESCRIPTION
This should be the job of another library, and the caller can just pass
in the looked up GID.

Since go-plugin-helpers uses this library, it also means the a plugin
must have `/etc/group` in it's rootfs with an entry in it.
Not all that bad, but a major pain when building a static binary to be
used as a plugin.

In any case, the lookup is only correct by luck, it's better to have the
caller of this library look up the gid as makes sense for the platform
they are on.

As is, this is a huge pain to deal with when developing on a non-Linux platform.