### PR TITLE
Update system cert pool update for Go 1.8

### DIFF
--- a/tlsconfig/certpool_go17.go
+++ b/tlsconfig/certpool_go17.go
@@ -1,4 +1,4 @@
-// +build go1.7
+// +build go1.7,!go1.8
 
 package tlsconfig
 
@@ -14,7 +14,7 @@ import (
 func SystemCertPool() (*x509.CertPool, error) {
 	certpool, err := x509.SystemCertPool()
 	if err != nil && runtime.GOOS == "windows" {
-		logrus.Warnf("Unable to use system certificate pool: %v", err)
+		logrus.Infof("Unable to use system certificate pool: %v", err)
 		return x509.NewCertPool(), nil
 	}
 	return certpool, err

--- a/tlsconfig/certpool_go18.go
+++ b/tlsconfig/certpool_go18.go
@@ -1,0 +1,10 @@
+// +build go1.8
+
+package tlsconfig
+
+import "crypto/x509"
+
+// SystemCertPool returns the system cert pool
+func SystemCertPool() (*x509.CertPool, error) {
+	return x509.SystemCertPool()
+}


### PR DESCRIPTION
Go 1.8 adds support for windows certificate pool, ensure
that the system cert pool is just called directly. Any
error in windows should propagate to the caller.

Change log message for windows error from warn to info
since it is not actionable in go 1.7.