### PR TITLE
sockets: close net.Listener after failed Chown

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -21,6 +21,7 @@ func NewUnixSocket(path string, gid int) (net.Listener, error) {
 		return nil, err
 	}
 	if err := os.Chown(path, 0, gid); err != nil {
+		l.Close()
 		return nil, err
 	}
 	if err := os.Chmod(path, 0660); err != nil {


### PR DESCRIPTION
Make sure file descriptor doesn't leak after failed Chown.