### PR TITLE
Add flag to the tls config that determines to use the system cert pool or an empty pool

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -29,6 +29,11 @@ type Options struct {
 	InsecureSkipVerify bool
 	// server-only option
 	ClientAuth tls.ClientAuthType
+
+	// If ExclusiveRootPools is set, then if a CA file is provided, the root pool used for TLS
+	// creds will include exclusively the roots in that CA file.  If no CA file is provided,
+	// the system pool will be used.
+	ExclusiveRootPools bool
 }
 
 // Extra (server-side) accepted CBC cipher suites - will phase out in the future
@@ -66,11 +71,19 @@ func ClientDefault() *tls.Config {
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
-func certPool(caFile string) (*x509.CertPool, error) {
+func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 	// If we should verify the server, we need to load a trusted ca
-	certPool, err := SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to read system certificates: %v", err)
+	var (
+		certPool *x509.CertPool
+		err      error
+	)
+	if exclusivePool {
+		certPool = x509.NewCertPool()
+	} else {
+		certPool, err = SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read system certificates: %v", err)
+		}
 	}
 	pem, err := ioutil.ReadFile(caFile)
 	if err != nil {
@@ -88,7 +101,7 @@ func Client(options Options) (*tls.Config, error) {
 	tlsConfig := ClientDefault()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
 	if !options.InsecureSkipVerify && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile)
+		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +132,7 @@ func Server(options Options) (*tls.Config, error) {
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	if options.ClientAuth >= tls.VerifyClientCertIfGiven && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile)
+		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
 		if err != nil {
 			return nil, err
 		}

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -21,6 +21,37 @@ import (
 	"time"
 )
 
+// This is the currently active LetsEncrypt IdenTrust cross-signed CA cert.  It expires Mar 17, 2021.
+const systemRootTrustedCert = `
+-----BEGIN CERTIFICATE-----
+MIIEkjCCA3qgAwIBAgIQCgFBQgAAAVOFc2oLheynCDANBgkqhkiG9w0BAQsFADA/
+MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
+DkRTVCBSb290IENBIFgzMB4XDTE2MDMxNzE2NDA0NloXDTIxMDMxNzE2NDA0Nlow
+SjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUxldCdzIEVuY3J5cHQxIzAhBgNVBAMT
+GkxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzMIIBIjANBgkqhkiG9w0BAQEFAAOC
+AQ8AMIIBCgKCAQEAnNMM8FrlLke3cl03g7NoYzDq1zUmGSXhvb418XCSL7e4S0EF
+q6meNQhY7LEqxGiHC6PjdeTm86dicbp5gWAf15Gan/PQeGdxyGkOlZHP/uaZ6WA8
+SMx+yk13EiSdRxta67nsHjcAHJyse6cF6s5K671B5TaYucv9bTyWaN8jKkKQDIZ0
+Z8h/pZq4UmEUEz9l6YKHy9v6Dlb2honzhT+Xhq+w3Brvaw2VFn3EK6BlspkENnWA
+a6xK8xuQSXgvopZPKiAlKQTGdMDQMc2PMTiVFrqoM7hD8bEfwzB/onkxEz0tNvjj
+/PIzark5McWvxI0NHWQWM6r6hCm21AvA2H3DkwIDAQABo4IBfTCCAXkwEgYDVR0T
+AQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwfwYIKwYBBQUHAQEEczBxMDIG
+CCsGAQUFBzABhiZodHRwOi8vaXNyZy50cnVzdGlkLm9jc3AuaWRlbnRydXN0LmNv
+bTA7BggrBgEFBQcwAoYvaHR0cDovL2FwcHMuaWRlbnRydXN0LmNvbS9yb290cy9k
+c3Ryb290Y2F4My5wN2MwHwYDVR0jBBgwFoAUxKexpHsscfrb4UuQdf/EFWCFiRAw
+VAYDVR0gBE0wSzAIBgZngQwBAgEwPwYLKwYBBAGC3xMBAQEwMDAuBggrBgEFBQcC
+ARYiaHR0cDovL2Nwcy5yb290LXgxLmxldHNlbmNyeXB0Lm9yZzA8BgNVHR8ENTAz
+MDGgL6AthitodHRwOi8vY3JsLmlkZW50cnVzdC5jb20vRFNUUk9PVENBWDNDUkwu
+Y3JsMB0GA1UdDgQWBBSoSmpjBH3duubRObemRWXv86jsoTANBgkqhkiG9w0BAQsF
+AAOCAQEA3TPXEfNjWDjdGBX7CVW+dla5cEilaUcne8IkCJLxWh9KEik3JHRRHGJo
+uM2VcGfl96S8TihRzZvoroed6ti6WqEBmtzw3Wodatg+VyOeph4EYpr/1wXKtx8/
+wApIvJSwtmVi4MFU5aMqrSDE6ea73Mj2tcMyo5jMd6jmeWUHK8so/joWUoHOUgwu
+X4Po1QYz+3dszkDqMp4fklxBwXRsW10KXzPMTZ+sOPAveyxindmjkW8lGy+QsRlG
+PfZ+G6Z6h7mjem0Y+iWlkYcV4PIWL1iwBi8saCbGS5jN2p8M+X+Q7UNKEkROb3N6
+KOqkqm57TH2H3eDJAkSnh6/DNFu0Qg==
+-----END CERTIFICATE-----
+`
+
 var certTemplate = x509.Certificate{
 	SerialNumber: big.NewInt(199999),
 	Subject: pkix.Name{
@@ -30,13 +61,19 @@ var certTemplate = x509.Certificate{
 	NotAfter:  time.Now().AddDate(1, 1, 1),
 
 	KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-	ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+	ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning, x509.ExtKeyUsageAny},
 
 	BasicConstraintsValid: true,
 }
 
-func generateCertificate(t *testing.T, signer crypto.Signer, out io.Writer) {
-	derBytes, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, signer.Public(), signer)
+func generateCertificate(t *testing.T, signer crypto.Signer, out io.Writer, isCA bool) {
+	template := certTemplate
+	template.IsCA = isCA
+	if isCA {
+		template.KeyUsage = template.KeyUsage | x509.KeyUsageCertSign
+		template.MaxPathLen = 1
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &certTemplate, signer.Public(), signer)
 	if err != nil {
 		t.Fatal("Unable to generate a certificate", err.Error())
 	}
@@ -46,7 +83,7 @@ func generateCertificate(t *testing.T, signer crypto.Signer, out io.Writer) {
 	}
 }
 
-// generates a multiple-certificate file with both RSA and ECDSA certs and
+// generates a multiple-certificate CA file with both RSA and ECDSA certs and
 // returns the filename so that cleanup can be deferred.
 func generateMultiCert(t *testing.T, tempDir string) string {
 	certOut, err := os.Create(filepath.Join(tempDir, "multi"))
@@ -65,7 +102,7 @@ func generateMultiCert(t *testing.T, tempDir string) string {
 	}
 
 	for _, signer := range []crypto.Signer{rsaKey, ecKey} {
-		generateCertificate(t, signer, certOut)
+		generateCertificate(t, signer, certOut, true)
 	}
 
 	return certOut.Name()
@@ -96,7 +133,7 @@ func generateCertAndKey(t *testing.T, tempDir string) (string, string) {
 	}
 	defer certOut.Close()
 
-	generateCertificate(t, rsaKey, certOut)
+	generateCertificate(t, rsaKey, certOut, false)
 
 	return keyOut.Name(), certOut.Name()
 }
@@ -240,8 +277,103 @@ func TestConfigServerTLSClientCASet(t *testing.T) {
 	if tlsConfig.ClientAuth != tls.VerifyClientCertIfGiven {
 		t.Fatal("ClientAuth was not set to what was in the options")
 	}
-	if tlsConfig.ClientCAs == nil || len(tlsConfig.ClientCAs.Subjects()) != 2 {
+	basePool, err := SystemCertPool()
+	if err != nil {
+		basePool = x509.NewCertPool()
+	}
+	// because we are not enabling `ExclusiveRootPools`, any root pool will also contain the system roots
+	if tlsConfig.ClientCAs == nil || len(tlsConfig.ClientCAs.Subjects()) != len(basePool.Subjects())+2 {
 		t.Fatalf("Client CAs were never set correctly")
+	}
+}
+
+// Exclusive root pools determines whether the CA pool will be a union of the system
+// certificate pool and custom certs, or an exclusive or of the custom certs and system pool
+func TestConfigServerExclusiveRootPools(t *testing.T) {
+	tempDir := makeTempDir(t)
+	defer os.RemoveAll(tempDir)
+	key, cert := generateCertAndKey(t, tempDir)
+	ca := generateMultiCert(t, tempDir)
+
+	caBytes, err := ioutil.ReadFile(ca)
+	if err != nil {
+		t.Fatal("Unable to read CA certs", err)
+	}
+
+	var testCerts []*x509.Certificate
+	for _, pemBytes := range [][]byte{caBytes, []byte(systemRootTrustedCert)} {
+		pemBlock, _ := pem.Decode(pemBytes)
+		if pemBlock == nil {
+			t.Fatal("Malformed certificate")
+		}
+		cert, err := x509.ParseCertificate(pemBlock.Bytes)
+		if err != nil {
+			t.Fatal("Unable to parse certificate")
+		}
+		testCerts = append(testCerts, cert)
+	}
+
+	// ExclusiveRootPools not set, so should be able to verify both system-signed certs
+	// and custom CA-signed certs
+	tlsConfig, err := Server(Options{
+		CertFile:   cert,
+		KeyFile:    key,
+		ClientAuth: tls.VerifyClientCertIfGiven,
+		CAFile:     ca,
+	})
+
+	if err != nil || tlsConfig == nil {
+		t.Fatal("Unable to configure server TLS", err)
+	}
+
+	for i, cert := range testCerts {
+		if _, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs}); err != nil {
+			t.Fatalf("Unable to verify certificate %d: %v", i, err)
+		}
+	}
+
+	// ExclusiveRootPools set and custom CA provided, so system certs should not be verifiable
+	// and custom CA-signed certs should be verifiable
+	tlsConfig, err = Server(Options{
+		CertFile:           cert,
+		KeyFile:            key,
+		ClientAuth:         tls.VerifyClientCertIfGiven,
+		CAFile:             ca,
+		ExclusiveRootPools: true,
+	})
+
+	if err != nil || tlsConfig == nil {
+		t.Fatal("Unable to configure server TLS", err)
+	}
+
+	for i, cert := range testCerts {
+		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
+		switch {
+		case i == 0 && err != nil:
+			t.Fatal("Unable to verify custom certificate, even though the root pool should have only the custom CA", err)
+		case i == 1 && err == nil:
+			t.Fatal("Successfully verified system root-signed certificate though the root pool should have only the cusotm CA", err)
+		}
+	}
+
+	// No CA file provided, system cert should be verifiable only
+	tlsConfig, err = Server(Options{
+		CertFile: cert,
+		KeyFile:  key,
+	})
+
+	if err != nil || tlsConfig == nil {
+		t.Fatal("Unable to configure server TLS", err)
+	}
+
+	for i, cert := range testCerts {
+		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
+		switch {
+		case i == 1 && err != nil:
+			t.Fatal("Unable to verify system root-signed certificate, even though the root pool should be the system pool only", err)
+		case i == 0 && err == nil:
+			t.Fatal("Successfully verified custom certificate though the root pool should be the system pool only", err)
+		}
 	}
 }
 
@@ -310,8 +442,12 @@ func TestConfigClientTLSRootCAFileWithOneCert(t *testing.T) {
 	if err != nil || tlsConfig == nil {
 		t.Fatal("Unable to configure client TLS", err)
 	}
-
-	if tlsConfig.RootCAs == nil || len(tlsConfig.RootCAs.Subjects()) != 2 {
+	basePool, err := SystemCertPool()
+	if err != nil {
+		basePool = x509.NewCertPool()
+	}
+	// because we are not enabling `ExclusiveRootPools`, any root pool will also contain the system roots
+	if tlsConfig.RootCAs == nil || len(tlsConfig.RootCAs.Subjects()) != len(basePool.Subjects())+2 {
 		t.Fatal("Root CAs not set properly", err)
 	}
 	if tlsConfig.Certificates != nil {
@@ -387,5 +523,83 @@ func TestConfigClientTLSValidClientCertAndKey(t *testing.T) {
 
 	if tlsConfig.RootCAs != nil {
 		t.Fatal("Root CAs should not have been set", err)
+	}
+}
+
+// Exclusive root pools determines whether the CA pool will be a union of the system
+// certificate pool and custom certs, or an exclusive or of the custom certs and system pool
+func TestConfigClientExclusiveRootPools(t *testing.T) {
+	tempDir := makeTempDir(t)
+	defer os.RemoveAll(tempDir)
+	ca := generateMultiCert(t, tempDir)
+
+	caBytes, err := ioutil.ReadFile(ca)
+	if err != nil {
+		t.Fatal("Unable to read CA certs", err)
+	}
+
+	var testCerts []*x509.Certificate
+	for _, pemBytes := range [][]byte{caBytes, []byte(systemRootTrustedCert)} {
+		pemBlock, _ := pem.Decode(pemBytes)
+		if pemBlock == nil {
+			t.Fatal("Malformed certificate")
+		}
+		cert, err := x509.ParseCertificate(pemBlock.Bytes)
+		if err != nil {
+			t.Fatal("Unable to parse certificate")
+		}
+		testCerts = append(testCerts, cert)
+	}
+
+	// ExclusiveRootPools not set, so should be able to verify both system-signed certs
+	// and custom CA-signed certs
+	tlsConfig, err := Client(Options{CAFile: ca})
+
+	if err != nil || tlsConfig == nil {
+		t.Fatal("Unable to configure client TLS", err)
+	}
+
+	for i, cert := range testCerts {
+		if _, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs}); err != nil {
+			t.Fatalf("Unable to verify certificate %d: %v", i, err)
+		}
+	}
+
+	// ExclusiveRootPools set and custom CA provided, so system certs should not be verifiable
+	// and custom CA-signed certs should be verifiable
+	tlsConfig, err = Client(Options{
+		CAFile:             ca,
+		ExclusiveRootPools: true,
+	})
+
+	if err != nil || tlsConfig == nil {
+		t.Fatal("Unable to configure client TLS", err)
+	}
+
+	for i, cert := range testCerts {
+		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
+		switch {
+		case i == 0 && err != nil:
+			t.Fatal("Unable to verify custom certificate, even though the root pool should have only the custom CA", err)
+		case i == 1 && err == nil:
+			t.Fatal("Successfully verified system root-signed certificate though the root pool should have only the cusotm CA", err)
+		}
+	}
+
+	// No CA file provided, system cert should be verifiable only
+	tlsConfig, err = Client(Options{})
+
+	if err != nil || tlsConfig == nil {
+		t.Fatal("Unable to configure client TLS", err)
+	}
+
+	for i, cert := range testCerts {
+		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
+		switch {
+		case i == 1 && err != nil:
+			t.Fatal("Unable to verify system root-signed certificate, even though the root pool should be the system pool only", err)
+		case i == 0 && err == nil:
+			t.Fatal("Successfully verified custom certificate though the root pool should be the system pool only", err)
+		}
 	}
 }


### PR DESCRIPTION
This is a stab at fixing https://github.com/docker/docker/issues/30450#issuecomment-278852038.

Note:  I'm not attached to the name of the flag - I'm very bad at naming things.  I just wanted to name it something does not change existing behavior if set to `false` (zero value).

@dmcgowan @nathanleclaire @diogomonica