### PR TITLE
Add minimum version to options, needed to fix docker/docker#30258

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -29,11 +29,11 @@ type Options struct {
 	InsecureSkipVerify bool
 	// server-only option
 	ClientAuth tls.ClientAuthType
-
 	// If ExclusiveRootPools is set, then if a CA file is provided, the root pool used for TLS
 	// creds will include exclusively the roots in that CA file.  If no CA file is provided,
 	// the system pool will be used.
 	ExclusiveRootPools bool
+	MinVersion         uint16
 }
 
 // Extra (server-side) accepted CBC cipher suites - will phase out in the future
@@ -50,6 +50,15 @@ var acceptedCBCCiphers = []uint16{
 // options struct but wants to use a commonly accepted set of TLS cipher suites, with
 // known weak algorithms removed.
 var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers...)
+
+// allTLSVersions lists all the TLS versions and is used by the code that validates
+// a uint16 value as a TLS version.
+var allTLSVersions = map[uint16]struct{}{
+	tls.VersionSSL30: {},
+	tls.VersionTLS10: {},
+	tls.VersionTLS11: {},
+	tls.VersionTLS12: {},
+}
 
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
 func ServerDefault() *tls.Config {
@@ -96,6 +105,28 @@ func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 	return certPool, nil
 }
 
+// isValidMinVersion checks that the input value is a valid tls minimum version
+func isValidMinVersion(version uint16) bool {
+	_, ok := allTLSVersions[version]
+	return ok
+}
+
+// adjustMinVersion sets the MinVersion on `config`, the input configuration.
+// It assumes the current MinVersion on the `config` is the lowest allowed.
+func adjustMinVersion(options Options, config *tls.Config) error {
+	if options.MinVersion > 0 {
+		if !isValidMinVersion(options.MinVersion) {
+			return fmt.Errorf("Invalid minimum TLS version: %x", options.MinVersion)
+		}
+		if options.MinVersion < config.MinVersion {
+			return fmt.Errorf("Requested minimum TLS version is too low. Should be at-least: %x", config.MinVersion)
+		}
+		config.MinVersion = options.MinVersion
+	}
+
+	return nil
+}
+
 // Client returns a TLS configuration meant to be used by a client.
 func Client(options Options) (*tls.Config, error) {
 	tlsConfig := ClientDefault()
@@ -114,6 +145,10 @@ func Client(options Options) (*tls.Config, error) {
 			return nil, fmt.Errorf("Could not load X509 key pair: %v. Make sure the key is not encrypted", err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{tlsCert}
+	}
+
+	if err := adjustMinVersion(options, tlsConfig); err != nil {
+		return nil, err
 	}
 
 	return tlsConfig, nil
@@ -138,5 +173,10 @@ func Server(options Options) (*tls.Config, error) {
 		}
 		tlsConfig.ClientCAs = CAs
 	}
+
+	if err := adjustMinVersion(options, tlsConfig); err != nil {
+		return nil, err
+	}
+
 	return tlsConfig, nil
 }


### PR DESCRIPTION
This is an attempt to add the code needed for fixing [docker/docker#30258](https://github.com/docker/docker/issues/30258). 

If the PR is approved, I can add code to docker/docker for passing the minimum TLS version to go-connections. 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>