### PR TITLE
Remove punctuation at the end of 2 error strings to fix lint

### DIFF
--- a/nat/parse.go
+++ b/nat/parse.go
@@ -33,7 +33,7 @@ func PartParser(template, data string) (map[string]string, error) {
 // ParsePortRange parses and validates the specified string as a port-range (8000-9000)
 func ParsePortRange(ports string) (uint64, uint64, error) {
 	if ports == "" {
-		return 0, 0, fmt.Errorf("Empty string specified for ports.")
+		return 0, 0, fmt.Errorf("Empty string specified for ports")
 	}
 	if !strings.Contains(ports, "-") {
 		start, err := strconv.ParseUint(ports, 10, 16)

--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -163,7 +163,7 @@ func Server(options Options) (*tls.Config, error) {
 		if os.IsNotExist(err) {
 			return nil, fmt.Errorf("Could not load X509 key pair (cert: %q, key: %q): %v", options.CertFile, options.KeyFile, err)
 		}
-		return nil, fmt.Errorf("Error reading X509 key pair (cert: %q, key: %q): %v. Make sure the key is not encrypted.", options.CertFile, options.KeyFile, err)
+		return nil, fmt.Errorf("Error reading X509 key pair (cert: %q, key: %q): %v. Make sure the key is not encrypted", options.CertFile, options.KeyFile, err)
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	if options.ClientAuth >= tls.VerifyClientCertIfGiven && options.CAFile != "" {


### PR DESCRIPTION
Master has been failing with the following:

```
nat/parse.go:36:27: error strings should not be capitalized or end with punctuation or a newline
tlsconfig/config.go:166:26: error strings should not be capitalized or end with punctuation or a newline
```

All of the errors we return seem to be capitalized, and somehow that doesn't trigger the lint errors despite it saying that error strings should not be capitalized, so it seems like punctation that's the problem.

Alternately if we wanted to lower-case all of these errors I'll be happy to do that too.