### PR TITLE
add unix-over-ssh transport

### DIFF
--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -3,9 +3,14 @@ package sockets
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
+
+	"github.com/docker/go-connections/sshutils"
+	"golang.org/x/crypto/ssh"
 )
 
 // Why 32? See https://github.com/docker/docker/pull/8035.
@@ -24,6 +29,8 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 		return configureUnixTransport(tr, proto, addr)
 	case "npipe":
 		return configureNpipeTransport(tr, proto, addr)
+	case "ssh": // unix over ssh
+		return configureSSHTransport(tr, proto, addr)
 	default:
 		tr.Proxy = http.ProxyFromEnvironment
 		dialer, err := DialerFromEnvironment(&net.Dialer{
@@ -35,4 +42,48 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 		tr.Dial = dialer.Dial
 	}
 	return nil
+}
+
+func configureSSHTransport(tr *http.Transport, proto, addr string) error {
+	_, dialer, err := prepareSSH(addr)
+	if err != nil {
+		return err
+	}
+	tr.Dial = func(_, _ string) (net.Conn, error) {
+		return dialer()
+	}
+	return nil
+}
+
+// DialSSH connects to a Unix socket over SSH.
+func DialSSH(addr string) (net.Conn, error) {
+	_, dialer, err := prepareSSH(addr)
+	if err != nil {
+		return nil, err
+	}
+	return dialer()
+}
+
+func prepareSSH(addr string) (*ssh.Client, func() (net.Conn, error), error) {
+	u, err := url.Parse("ssh://" + addr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if u.User == nil || u.User.Username() == "" {
+		return nil, nil, fmt.Errorf("ssh requires username")
+	}
+	if _, ok := u.User.Password(); ok {
+		return nil, nil, fmt.Errorf("ssh does not accept plain-text password")
+	}
+	if u.Path == "" {
+		return nil, nil, fmt.Errorf("ssh requires socket path")
+	}
+	sshClient, err := sshutils.Dial(u.User.Username(), "tcp", u.Host)
+	if err != nil {
+		return nil, nil, err
+	}
+	dialer := func() (net.Conn, error) {
+		return sshClient.Dial("unix", u.Path)
+	}
+	return sshClient, dialer, nil
 }

--- a/sshutils/auth.go
+++ b/sshutils/auth.go
@@ -1,0 +1,74 @@
+package sshutils
+
+import (
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type config struct {
+	identityFiles map[string][]byte // key: file path, value: content
+	sshAuthSock   string            // socket file path
+}
+
+type envGetter func(string) string
+type fileReader func(string) ([]byte, error)
+
+func resolveAuthMethods(home string, envG envGetter, fileR fileReader) ([]ssh.AuthMethod, error) {
+	c, err := resolveConfig(home, envG, fileR)
+	if err != nil {
+		return nil, err
+	}
+
+	var methods []ssh.AuthMethod
+	if method := resolveAgent(c); method != nil {
+		methods = append(methods, method)
+	}
+	if method := resolvePublicKeys(c); method != nil {
+		methods = append(methods, method)
+	}
+	return methods, nil
+}
+
+// resolveConfig resolves the config
+// TODO: use ~/.ssh/config and /etc/ssh/ssh_config
+func resolveConfig(home string, envG envGetter, fileR fileReader) (*config, error) {
+	var c config
+	dotSSH := filepath.Join(home, ".ssh")
+	identityFileCandidates := []string{
+		// see ssh_config(5)
+		filepath.Join(dotSSH, "id_rsa"),
+		filepath.Join(dotSSH, "id_ed25519"),
+		filepath.Join(dotSSH, "id_ecdsa"),
+		filepath.Join(dotSSH, "id_dsa"),
+		filepath.Join(dotSSH, "identity"),
+	}
+	c.identityFiles = make(map[string][]byte, 0)
+	for _, cand := range identityFileCandidates {
+		b, err := fileR(cand)
+		if err == nil {
+			c.identityFiles[cand] = b
+		}
+		// we can safely ignore err
+	}
+	c.sshAuthSock = envG("SSH_AUTH_SOCK")
+	return &c, nil
+}
+
+func resolvePublicKeys(c *config) ssh.AuthMethod {
+	var signers []ssh.Signer
+	for filePath, b := range c.identityFiles {
+		signer, err := ssh.ParsePrivateKey(b)
+		if err == nil {
+			logrus.Debugf("detected private key %s", filePath)
+			signers = append(signers, signer)
+		} else {
+			logrus.Warnf("could not read private key %s: %v",
+				filePath, err)
+		}
+	}
+	auth := ssh.PublicKeys(signers...)
+	return auth
+}

--- a/sshutils/auth_unix.go
+++ b/sshutils/auth_unix.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package sshutils
+
+import (
+	"net"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func resolveAgent(c *config) ssh.AuthMethod {
+	if sshAgent, err := net.Dial("unix", c.sshAuthSock); err == nil {
+		logrus.Debugf("detected ssh agent socket")
+		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
+	}
+	return nil
+}

--- a/sshutils/auth_windows.go
+++ b/sshutils/auth_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package sshutils
+
+import (
+	"golang.org/x/crypto/ssh"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/davidmz/go-pageant"
+)
+
+func resolveAgent(c *config) ssh.AuthMethod {
+	if pageant.Available() {
+		logrus.Debugf("detected pageant window")
+		return ssh.PublicKeysCallback(pageant.New().Signers)
+	}
+	return nil
+}

--- a/sshutils/sshutils.go
+++ b/sshutils/sshutils.go
@@ -1,0 +1,43 @@
+// Package sshutils provides utilities for SSH
+package sshutils
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// ResolveAuthMethods returns the list of available auth methods.
+// Currently supported methods:
+//  - ssh-agent (on Unixen)
+//  - pageant   (on Windows)
+//  - publickey (files under $HOME/.ssh)
+//
+// Methods unlikely to be supported in future:
+//  - keyboard interactive
+//
+// NOTE: currently, ~/.ssh/config and /etc/ssh/ssh_config are unused.
+func ResolveAuthMethods() ([]ssh.AuthMethod, error) {
+	home, err := getHome()
+	if err != nil {
+		return nil, err
+	}
+	return resolveAuthMethods(home, os.Getenv, ioutil.ReadFile)
+}
+
+// Dial dials with available auth methods
+func Dial(user, n, addr string) (*ssh.Client, error) {
+	auths, err := ResolveAuthMethods()
+	if err != nil {
+		return nil, err
+	}
+	if len(auths) == 0 {
+		return nil, errors.New("no auth method found")
+	}
+	return ssh.Dial(n, addr, &ssh.ClientConfig{
+		User: user,
+		Auth: auths,
+	})
+}

--- a/sshutils/sshutils_unix.go
+++ b/sshutils/sshutils_unix.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+package sshutils
+
+import (
+	"errors"
+	"os"
+)
+
+func getHome() (string, error) {
+	// TODO: use docker/pkg/homedir (mess for static bin, see comments in homedir_linux.go)
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("HOME unset")
+	}
+	return home, nil
+}

--- a/sshutils/sshutils_windows.go
+++ b/sshutils/sshutils_windows.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package sshutils
+
+import (
+	"errors"
+	"os"
+)
+
+func getHome() (string, error) {
+	// TODO: use docker/pkg/homedir (mess for static bin, see comments in homedir_linux.go)
+	home := os.Getenv("USERPROFILE")
+	if home == "" {
+		return "", errors.New("USERPROFILE unset")
+	}
+	return home, nil
+}


### PR DESCRIPTION
This PR supports connecting to a Unix socket over SSH.

This PR is required by https://github.com/docker/docker/pull/32161 , and integration test for this PR is already covered in that PR.

Requires latest golang/crypto@3cddcd6758340b7620ed7f7895422317fab91e45


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>