### PR TITLE
Remove logrus dependency from any packages in go-connections

### DIFF
--- a/proxy/logger.go
+++ b/proxy/logger.go
@@ -1,0 +1,11 @@
+package proxy
+
+type logger interface {
+	Printf(format string, args ...interface{})
+}
+
+type noopLogger struct{}
+
+func (l *noopLogger) Printf(_ string, _ ...interface{}) {
+	// Do nothing :)
+}

--- a/proxy/tcp_proxy.go
+++ b/proxy/tcp_proxy.go
@@ -4,37 +4,43 @@ import (
 	"io"
 	"net"
 	"syscall"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // TCPProxy is a proxy for TCP connections. It implements the Proxy interface to
 // handle TCP traffic forwarding between the frontend and backend addresses.
 type TCPProxy struct {
+	Logger       logger
 	listener     *net.TCPListener
 	frontendAddr *net.TCPAddr
 	backendAddr  *net.TCPAddr
 }
 
 // NewTCPProxy creates a new TCPProxy.
-func NewTCPProxy(frontendAddr, backendAddr *net.TCPAddr) (*TCPProxy, error) {
+func NewTCPProxy(frontendAddr, backendAddr *net.TCPAddr, ops ...func(*TCPProxy)) (*TCPProxy, error) {
 	listener, err := net.ListenTCP("tcp", frontendAddr)
 	if err != nil {
 		return nil, err
 	}
 	// If the port in frontendAddr was 0 then ListenTCP will have a picked
 	// a port to listen on, hence the call to Addr to get that actual port:
-	return &TCPProxy{
+	proxy := &TCPProxy{
 		listener:     listener,
 		frontendAddr: listener.Addr().(*net.TCPAddr),
 		backendAddr:  backendAddr,
-	}, nil
+		Logger:       &noopLogger{},
+	}
+
+	for _, op := range ops {
+		op(proxy)
+	}
+
+	return proxy, nil
 }
 
 func (proxy *TCPProxy) clientLoop(client *net.TCPConn, quit chan bool) {
 	backend, err := net.DialTCP("tcp", nil, proxy.backendAddr)
 	if err != nil {
-		logrus.Printf("Can't forward traffic to backend tcp/%v: %s\n", proxy.backendAddr, err)
+		proxy.Logger.Printf("Can't forward traffic to backend tcp/%v: %s\n", proxy.backendAddr, err)
 		client.Close()
 		return
 	}
@@ -82,7 +88,7 @@ func (proxy *TCPProxy) Run() {
 	for {
 		client, err := proxy.listener.Accept()
 		if err != nil {
-			logrus.Printf("Stopping proxy on tcp/%v for tcp/%v (%s)", proxy.frontendAddr, proxy.backendAddr, err)
+			proxy.Logger.Printf("Stopping proxy on tcp/%v for tcp/%v (%s)", proxy.frontendAddr, proxy.backendAddr, err)
 			return
 		}
 		go proxy.clientLoop(client.(*net.TCPConn), quit)

--- a/tlsconfig/certpool_go17.go
+++ b/tlsconfig/certpool_go17.go
@@ -5,8 +5,6 @@ package tlsconfig
 import (
 	"crypto/x509"
 	"runtime"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // SystemCertPool returns a copy of the system cert pool,
@@ -14,7 +12,6 @@ import (
 func SystemCertPool() (*x509.CertPool, error) {
 	certpool, err := x509.SystemCertPool()
 	if err != nil && runtime.GOOS == "windows" {
-		logrus.Infof("Unable to use system certificate pool: %v", err)
 		return x509.NewCertPool(), nil
 	}
 	return certpool, err

--- a/tlsconfig/certpool_other.go
+++ b/tlsconfig/certpool_other.go
@@ -5,12 +5,10 @@ package tlsconfig
 import (
 	"crypto/x509"
 
-	"github.com/Sirupsen/logrus"
 )
 
 // SystemCertPool returns an new empty cert pool,
 // accessing system cert pool is supported in go 1.7
 func SystemCertPool() (*x509.CertPool, error) {
-	logrus.Warn("Unable to use system certificate pool: requires building with go 1.7 or later")
 	return x509.NewCertPool(), nil
 }

--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 )
 
@@ -106,7 +105,6 @@ func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 	if !certPool.AppendCertsFromPEM(pem) {
 		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)
 	}
-	logrus.Debugf("Trusting %d certs", len(certPool.Subjects()))
 	return certPool, nil
 }
 


### PR DESCRIPTION
To set a logger for the `Proxy` :

```go
proxy.NewTCPProxy(fontAddr, backAddr, func(proxy *TCPProxy) {
    proxy.Logger = logrus.New()
})
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>