### PR TITLE
Allow the config API consumer to modify the serv/client default configs

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -65,22 +65,34 @@ var allTLSVersions = map[uint16]struct{}{
 }
 
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
-func ServerDefault() *tls.Config {
-	return &tls.Config{
-		// Avoid fallback to SSL protocols < TLS1.0
+func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
+		// Avoid fallback by default to SSL protocols < TLS1.0
 		MinVersion:               tls.VersionTLS10,
 		PreferServerCipherSuites: true,
 		CipherSuites:             DefaultServerAcceptedCiphers,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
-func ClientDefault() *tls.Config {
-	return &tls.Config{
+func ClientDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
 		// Prefer TLS1.2 as the client minimum
 		MinVersion:   tls.VersionTLS12,
 		CipherSuites: clientCipherSuites,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -287,6 +287,44 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 	}
 }
 
+// If we provide a modifier to the server's default TLS configuration generator, it
+// should be applied accordingly
+func TestConfigServerDefaultWithTLSMinimumModifier(t *testing.T) {
+	tlsVersions := []uint16{
+		tls.VersionTLS11,
+		tls.VersionTLS12,
+	}
+
+	for _, tlsVersion := range tlsVersions {
+		servDefault := ServerDefault(func(c *tls.Config) {
+			c.MinVersion = tlsVersion
+		})
+
+		if servDefault.MinVersion != tlsVersion {
+			t.Fatalf("Unexpected min TLS version for default server TLS config: ", servDefault.MinVersion)
+		}
+	}
+}
+
+// If we provide a modifier to the client's default TLS configuration generator, it
+// should be applied accordingly
+func TestConfigClientDefaultWithTLSMinimumModifier(t *testing.T) {
+	tlsVersions := []uint16{
+		tls.VersionTLS11,
+		tls.VersionTLS12,
+	}
+
+	for _, tlsVersion := range tlsVersions {
+		clientDefault := ClientDefault(func(c *tls.Config) {
+			c.MinVersion = tlsVersion
+		})
+
+		if clientDefault.MinVersion != tlsVersion {
+			t.Fatalf("Unexpected min TLS version for default client TLS config: ", clientDefault.MinVersion)
+		}
+	}
+}
+
 // If a valid minimum version is specified in the options, the server's
 // minimum version should be set accordingly
 func TestConfigServerTLSMinVersionIsSetBasedOnOptions(t *testing.T) {


### PR DESCRIPTION
We need to adjust adjust the TLS minimum version from the server default's TLS config in the engine without breaking the interface in `go-connections`.

It's already possible to modify the more complete `Server()` configuration through the `options` parameter but not the `ServerDefault` one so we added a variadic modifier parameter.

ps: thanks @vdemeester.

cc @thaJeztah @vieux 

Signed-off-by: Nassim 'Nass' Eddequiouaq <eddequiouaq.nassim@gmail.com>