### PR TITLE
fix CI failure

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,5 +10,6 @@ test:
   pre:
     # run analysis before tests
     - go vet ./...
-    - test -z "$(golint ./... | tee /dev/stderr)"
+    # set min_confidence > 0.8 to ignore "error strings should not be capitalized or end with punctuation or a newline"
+    - test -z "$(golint -min_confidence 0.81 ./... | tee /dev/stderr)"
     - test -z "$(gofmt -s -l . | tee /dev/stderr)"

--- a/proxy/udp_proxy.go
+++ b/proxy/udp_proxy.go
@@ -65,7 +65,7 @@ func NewUDPProxy(frontendAddr, backendAddr *net.UDPAddr, ops ...func(*UDPProxy))
 		frontendAddr:   listener.LocalAddr().(*net.UDPAddr),
 		backendAddr:    backendAddr,
 		connTrackTable: make(connTrackMap),
-		Logger:       &noopLogger{},
+		Logger:         &noopLogger{},
 	}
 
 	for _, op := range ops {

--- a/tlsconfig/certpool_other.go
+++ b/tlsconfig/certpool_other.go
@@ -4,7 +4,6 @@ package tlsconfig
 
 import (
 	"crypto/x509"
-
 )
 
 // SystemCertPool returns an new empty cert pool,

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -301,7 +301,7 @@ func TestConfigServerDefaultWithTLSMinimumModifier(t *testing.T) {
 		})
 
 		if servDefault.MinVersion != tlsVersion {
-			t.Fatalf("Unexpected min TLS version for default server TLS config: ", servDefault.MinVersion)
+			t.Fatalf("Unexpected min TLS version for default server TLS config: %d", servDefault.MinVersion)
 		}
 	}
 }
@@ -320,7 +320,7 @@ func TestConfigClientDefaultWithTLSMinimumModifier(t *testing.T) {
 		})
 
 		if clientDefault.MinVersion != tlsVersion {
-			t.Fatalf("Unexpected min TLS version for default client TLS config: ", clientDefault.MinVersion)
+			t.Fatalf("Unexpected min TLS version for default client TLS config: %d", clientDefault.MinVersion)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

```
suda@ws01:~/gopath/src/github.com/docker/go-connections⟫ go vet ./...    
tlsconfig/config_test.go:304: no formatting directive in Fatalf call     
tlsconfig/config_test.go:323: no formatting directive in Fatalf call     
exit status 1                       
1 suda@ws01:~/gopath/src/github.com/docker/go-connections⟫ test -z "$(golint ./... | tee /dev/stderr)"                                            
nat/parse.go:36:27: error strings should not be capitalized or end with punctuation or a newline                                                  
tlsconfig/config.go:240:26: error strings should not be capitalized or end with punctuation or a newline                                          
1 suda@ws01:~/gopath/src/github.com/docker/go-connections⟫ test -z "$(gofmt -s -l . | tee /dev/stderr)"                                           
proxy/udp_proxy.go                  
tlsconfig/certpool_other.go         
1 suda@ws01:~/gopath/src/github.com/docker/go-connections⟫ 
```