### PR TITLE
Remove TLS_RSA ciphers from the default accepted cipher suite

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -46,8 +46,6 @@ var acceptedCBCCiphers = []uint16{
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
 	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
 }
 
 // DefaultServerAcceptedCiphers should be uses by code which already has a crypto/tls


### PR DESCRIPTION
It triggers warnings on various TLS/network scanners and is not considered as best security practice.

cc @thaJeztah @endophage @justincormack 

Signed-off-by: Nassim 'Nass' Eddequiouaq <eddequiouaq.nassim@gmail.com>