### PR TITLE
Remove server support for TLS 1.0 and 1.1

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -65,8 +65,8 @@ var allTLSVersions = map[uint16]struct{}{
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
 func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
 	tlsconfig := &tls.Config{
-		// Avoid fallback by default to SSL protocols < TLS1.0
-		MinVersion:               tls.VersionTLS10,
+		// Avoid fallback by default to SSL protocols < TLS1.2
+		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites:             DefaultServerAcceptedCiphers,
 	}

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -133,7 +133,7 @@ func TestConfigServerTLSServerCertsOnly(t *testing.T) {
 	if !tlsConfig.PreferServerCipherSuites {
 		t.Fatal("Expected server to prefer cipher suites")
 	}
-	if tlsConfig.MinVersion != tls.VersionTLS10 {
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
 		t.Fatal("Unexpected server TLS version")
 	}
 }
@@ -329,7 +329,6 @@ func TestConfigClientDefaultWithTLSMinimumModifier(t *testing.T) {
 // minimum version should be set accordingly
 func TestConfigServerTLSMinVersionIsSetBasedOnOptions(t *testing.T) {
 	versions := []uint16{
-		tls.VersionTLS11,
 		tls.VersionTLS12,
 	}
 	key, cert := getCertAndKey()


### PR DESCRIPTION
This should not be needed any more and is not recommended.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>