### PR TITLE
Replace deprecated Transport.Dial with Transport.DialContext

### DIFF
--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -32,7 +32,7 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 		if err != nil {
 			return err
 		}
-		tr.Dial = dialer.Dial
+		tr.DialContext = dialer.DialContext
 	}
 	return nil
 }

--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -18,8 +18,11 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 	}
 	// No need for compression in local communications.
 	tr.DisableCompression = true
-	tr.Dial = func(_, _ string) (net.Conn, error) {
-		return net.DialTimeout(proto, addr, defaultTimeout)
+	dialer := &net.Dialer{
+		Timeout: defaultTimeout,
+	}
+	tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, proto, addr)
 	}
 	return nil
 }

--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -15,7 +15,15 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	// No need for compression in local communications.
 	tr.DisableCompression = true
-	tr.Dial = func(_, _ string) (net.Conn, error) {
+	dialer := &net.Dialer{
+		Timeout: defaultTimeout,
+	}
+	tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		// DialPipeContext() has been added to winio:
+		// https://github.com/Microsoft/go-winio/commit/5fdbdcc2ae1c7e1073157fa7cb34a15eab472e1d
+		// However, a new version of winio with this commit has not been released yet.
+		// Continue to use DialPipe() until DialPipeContext() becomes available.
+		//return winio.DialPipeContext(ctx, addr)
 		return DialPipe(addr, defaultTimeout)
 	}
 	return nil


### PR DESCRIPTION
http.Transport.Dial is deprecated.  Other parts of Docker have been updated to use DialContext instead (for example: https://github.com/moby/moby/blob/master/client/options.go#L66), but go-connections is currently still using Dial.

This commit updates go-connections to use DialContext.