### PR TITLE
Fix problems introduced by #58

### DIFF
--- a/sockets/proxy.go
+++ b/sockets/proxy.go
@@ -2,11 +2,8 @@ package sockets
 
 import (
 	"net"
-	"net/url"
 	"os"
 	"strings"
-
-	"golang.org/x/net/proxy"
 )
 
 // GetProxyEnv allows access to the uppercase and the lowercase forms of
@@ -20,32 +17,12 @@ func GetProxyEnv(key string) string {
 	return proxyValue
 }
 
-// DialerFromEnvironment takes in a "direct" *net.Dialer and returns a
-// proxy.Dialer which will route the connections through the proxy using the
-// given dialer.
-func DialerFromEnvironment(direct *net.Dialer) (proxy.Dialer, error) {
-	allProxy := GetProxyEnv("all_proxy")
-	if len(allProxy) == 0 {
-		return direct, nil
-	}
-
-	proxyURL, err := url.Parse(allProxy)
-	if err != nil {
-		return direct, err
-	}
-
-	proxyFromURL, err := proxy.FromURL(proxyURL, direct)
-	if err != nil {
-		return direct, err
-	}
-
-	noProxy := GetProxyEnv("no_proxy")
-	if len(noProxy) == 0 {
-		return proxyFromURL, nil
-	}
-
-	perHost := proxy.NewPerHost(proxyFromURL, direct)
-	perHost.AddFromString(noProxy)
-
-	return perHost, nil
+// DialerFromEnvironment was previously used to configure a net.Dialer to route
+// connections through a SOCKS proxy.
+// DEPRECATED: SOCKS proxies are now supported by configuring only
+// http.Transport.Proxy, and no longer require changing http.Transport.Dial.
+// Therefore, only sockets.ConfigureTransport() needs to be called, and any
+// sockets.DialerFromEnvironment() calls can be dropped.
+func DialerFromEnvironment(direct *net.Dialer) (*net.Dialer, error) {
+	return direct, nil
 }

--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -3,7 +3,6 @@ package sockets
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"time"
 )
@@ -26,13 +25,6 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 		return configureNpipeTransport(tr, proto, addr)
 	default:
 		tr.Proxy = http.ProxyFromEnvironment
-		dialer, err := DialerFromEnvironment(&net.Dialer{
-			Timeout: defaultTimeout,
-		})
-		if err != nil {
-			return err
-		}
-		tr.DialContext = dialer.DialContext
 	}
 	return nil
 }

--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -3,6 +3,7 @@
 package sockets
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"

--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -1,6 +1,7 @@
 package sockets
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"time"
@@ -15,9 +16,6 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	// No need for compression in local communications.
 	tr.DisableCompression = true
-	dialer := &net.Dialer{
-		Timeout: defaultTimeout,
-	}
 	tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
 		// DialPipeContext() has been added to winio:
 		// https://github.com/Microsoft/go-winio/commit/5fdbdcc2ae1c7e1073157fa7cb34a15eab472e1d


### PR DESCRIPTION
So apparently I missed an import line in #58 (See #60 :man_facepalming:).  I've also since discovered problems with current versions of Go, which dropped support for golang.org/x/net/proxy.  This PR fixes both of those issues.