### PR TITLE
Fix problems introduced by #58 & #61

### DIFF
--- a/sockets/proxy.go
+++ b/sockets/proxy.go
@@ -1,12 +1,10 @@
 package sockets
 
 import (
+	"golang.org/x/net/proxy"
 	"net"
-	"net/url"
 	"os"
 	"strings"
-
-	"golang.org/x/net/proxy"
 )
 
 // GetProxyEnv allows access to the uppercase and the lowercase forms of
@@ -24,28 +22,5 @@ func GetProxyEnv(key string) string {
 // proxy.Dialer which will route the connections through the proxy using the
 // given dialer.
 func DialerFromEnvironment(direct *net.Dialer) (proxy.Dialer, error) {
-	allProxy := GetProxyEnv("all_proxy")
-	if len(allProxy) == 0 {
-		return direct, nil
-	}
-
-	proxyURL, err := url.Parse(allProxy)
-	if err != nil {
-		return direct, err
-	}
-
-	proxyFromURL, err := proxy.FromURL(proxyURL, direct)
-	if err != nil {
-		return direct, err
-	}
-
-	noProxy := GetProxyEnv("no_proxy")
-	if len(noProxy) == 0 {
-		return proxyFromURL, nil
-	}
-
-	perHost := proxy.NewPerHost(proxyFromURL, direct)
-	perHost.AddFromString(noProxy)
-
-	return perHost, nil
+	return direct, nil
 }

--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -3,7 +3,6 @@ package sockets
 
 import (
 	"errors"
-	"net"
 	"net/http"
 	"time"
 )
@@ -26,13 +25,6 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 		return configureNpipeTransport(tr, proto, addr)
 	default:
 		tr.Proxy = http.ProxyFromEnvironment
-		dialer, err := DialerFromEnvironment(&net.Dialer{
-			Timeout: defaultTimeout,
-		})
-		if err != nil {
-			return err
-		}
-		tr.DialContext = dialer.DialContext
 	}
 	return nil
 }

--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -3,6 +3,7 @@
 package sockets
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"

--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -1,6 +1,7 @@
 package sockets
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"time"
@@ -15,9 +16,7 @@ func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	// No need for compression in local communications.
 	tr.DisableCompression = true
-	dialer := &net.Dialer{
-		Timeout: defaultTimeout,
-	}
+
 	tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
 		// DialPipeContext() has been added to winio:
 		// https://github.com/Microsoft/go-winio/commit/5fdbdcc2ae1c7e1073157fa7cb34a15eab472e1d


### PR DESCRIPTION
I find there has a problem in #61(/sockets/sockets_windows)
/sockets/sockets_windows no longer need to declare `dialer`
(sorry my English is poor, Translate to google translate)