### PR TITLE
tlsconfig: remove support for deprecated tls.VersionSSL30

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -56,7 +56,6 @@ var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers
 // allTLSVersions lists all the TLS versions and is used by the code that validates
 // a uint16 value as a TLS version.
 var allTLSVersions = map[uint16]struct{}{
-	tls.VersionSSL30: {},
 	tls.VersionTLS10: {},
 	tls.VersionTLS11: {},
 	tls.VersionTLS12: {},

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -356,7 +356,7 @@ func TestConfigServerTLSMinVersionNotSetIfMinVersionIsTooLow(t *testing.T) {
 	key, cert := getCertAndKey()
 
 	_, err := Server(Options{
-		MinVersion: tls.VersionSSL30,
+		MinVersion: tls.VersionTLS10,
 		CertFile:   cert,
 		KeyFile:    key,
 	})


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

The Go authors deprecated support for SSLv3 in go 1.13. They've decided to remove it in go 1.14, and have already merged the commit. 

See: https://golang.org/issue/32716

This PR, or something like it, should probably land before February 2020.