### PR TITLE
Add TLS 1.3 to list of TLS versions

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -53,14 +53,6 @@ var acceptedCBCCiphers = []uint16{
 // known weak algorithms removed.
 var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers...)
 
-// allTLSVersions lists all the TLS versions and is used by the code that validates
-// a uint16 value as a TLS version.
-var allTLSVersions = map[uint16]struct{}{
-	tls.VersionTLS10: {},
-	tls.VersionTLS11: {},
-	tls.VersionTLS12: {},
-}
-
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
 func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
 	tlsconfig := &tls.Config{

--- a/tlsconfig/versions_go113.go
+++ b/tlsconfig/versions_go113.go
@@ -1,0 +1,16 @@
+// +build go1.13
+
+package tlsconfig
+
+import (
+	"crypto/tls"
+)
+
+// allTLSVersions lists all the TLS versions and is used by the code that validates
+// a uint16 value as a TLS version.
+var allTLSVersions = map[uint16]struct{}{
+	tls.VersionTLS10: {},
+	tls.VersionTLS11: {},
+	tls.VersionTLS12: {},
+	tls.VersionTLS13: {},
+}

--- a/tlsconfig/versions_other.go
+++ b/tlsconfig/versions_other.go
@@ -1,0 +1,15 @@
+// +build !go1.13
+
+package tlsconfig
+
+import (
+	"crypto/tls"
+)
+
+// allTLSVersions lists all the TLS versions and is used by the code that validates
+// a uint16 value as a TLS version.
+var allTLSVersions = map[uint16]struct{}{
+	tls.VersionTLS10: {},
+	tls.VersionTLS11: {},
+	tls.VersionTLS12: {},
+}


### PR DESCRIPTION
This const is available in Go 1.12 and up (although TLS1.3 is opt-in
for that version), so this patch gates the new version based on Go version.

From the Go 1.13 release notes https://golang.org/doc/go1.13#tls_1_3

> As announced in Go 1.12, Go 1.13 enables support for TLS 1.3 in the crypto/tls
> package by default. It can be disabled by adding the value tls13=0 to the GODEBUG
> environment variable. The opt-out will be removed in Go 1.14.
