### PR TITLE
configureNpipeTransport: use winio.DialPipeContext()

### DIFF
--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -17,12 +17,7 @@ func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	// No need for compression in local communications.
 	tr.DisableCompression = true
 	tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
-		// DialPipeContext() has been added to winio:
-		// https://github.com/Microsoft/go-winio/commit/5fdbdcc2ae1c7e1073157fa7cb34a15eab472e1d
-		// However, a new version of winio with this commit has not been released yet.
-		// Continue to use DialPipe() until DialPipeContext() becomes available.
-		//return winio.DialPipeContext(ctx, addr)
-		return DialPipe(addr, defaultTimeout)
+		return winio.DialPipeContext(ctx, addr)
 	}
 	return nil
 }


### PR DESCRIPTION
This is now in a released version of Microsoft/go-winio


Was going through changes since v0.4.0, and noticed https://github.com/docker/go-connections/pull/58#discussion_r277175135