### PR TITLE
Replace syscall.Unlink with os.Remove so that the directory(e.g. /run…

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -79,7 +79,7 @@ func WithChmod(mask os.FileMode) SockOption {
 
 // NewUnixSocketWithOpts creates a unix socket with the specified options
 func NewUnixSocketWithOpts(path string, opts ...SockOption) (net.Listener, error) {
-	if err := syscall.Unlink(path); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	mask := syscall.Umask(0777)


### PR DESCRIPTION
Docker start failed If docker's unix socket path exist，and it is a dir. 

we can reproduce it like thks.
1. make sure live-restore is false
2. start 20 containers with -v /run/docker.sock:/run/docker.sock and --restart always
```
#!/bin/bash

i=0
while [ ${i} -lt 20 ];
do
        docker run --name test-${i} -tid --restart always -v  /run/docker.sock:/run/docker.sock  busybox sleep 16881688
        ((i++))
done
```
3.  kill container process and restart dockerd
```
[root@centos1 workspace]# killall -9 sleep;usleep 100;systemctl restart docker
Job for docker.service failed because the control process exited with error code. See "systemctl status docker.service" and "journalctl -xe" for details.
[root@centos1 workspace]# ls /run/docker
docker/          dockershim.sock  docker.sock/   
```

we can see the dir /run/docker.sock/  is created and It causes docker to start failed.

use os.Remove can fix this issue.
