### PR TITLE
Revert "Replace syscall.Unlink with os.Remove so that the directory(eg. /run/docker.sock/) can be deleted"

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -79,7 +79,7 @@ func WithChmod(mask os.FileMode) SockOption {
 
 // NewUnixSocketWithOpts creates a unix socket with the specified options
 func NewUnixSocketWithOpts(path string, opts ...SockOption) (net.Listener, error) {
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+	if err := syscall.Unlink(path); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	mask := syscall.Umask(0777)


### PR DESCRIPTION
This reverts commit e37f6db96f63ded68813dd97e0ad109dfe9c5fd2 (https://github.com/docker/go-connections/pull/72); see the discussion on that PR for background

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>