### PR TITLE
CircleCI: run unit tests, and add test for Socket Permissions

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,11 @@ jobs:
       - run:
           name: gofmt
           command: test -z "$(gofmt -s -l . | tee /dev/stderr)"
+      - run:
+          name: Run tests
+          command: sudo -E env PATH=$PATH go test -v ./...
+          environment:
+            GOOS: linux
       # make sure that it passes build on both Linux and Windows
       - run:
           name: Build for Linux

--- a/sockets/unix_socket_test.go
+++ b/sockets/unix_socket_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"syscall"
 	"testing"
 )
 
@@ -47,12 +48,25 @@ func TestNewUnixSocket(t *testing.T) {
 
 func TestUnixSocketWithOpts(t *testing.T) {
 	uid, gid := os.Getuid(), os.Getgid()
+	perms := os.FileMode(0660)
 	path := "/tmp/test.sock"
 	echoStr := "hello"
-	l, err := NewUnixSocketWithOpts(path, WithChown(uid, gid), WithChmod(0660))
+	l, err := NewUnixSocketWithOpts(path, WithChown(uid, gid), WithChmod(perms))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer l.Close()
+	p, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Mode().Perm() != perms {
+		t.Fatalf("unexpected file permissions: expected: %#o, got: %#o", perms, p.Mode().Perm())
+	}
+	if stat, ok := p.Sys().(*syscall.Stat_t); ok {
+		if stat.Uid != uint32(uid) || stat.Gid != uint32(gid) {
+			t.Fatalf("unexpected file ownership: expected: %d:%d, got: %d:%d", uid, gid, stat.Uid, stat.Gid)
+		}
+	}
 	runTest(t, path, l, echoStr)
 }


### PR DESCRIPTION
For some reason, CircleCI only ran a _build_, but did not run any test. This patch adds a "test" step to CircleCI. `root` is required for some of the tests (doing chown/chmod).

Also adding a test to verify socket ownership/permissions