### PR TITLE
support both square brackets and raw syntax for IPV6

### DIFF
--- a/nat/nat.go
+++ b/nat/nat.go
@@ -175,13 +175,16 @@ func splitParts(rawport string) (string, string, string) {
 // ParsePortSpec parses a port specification string into a slice of PortMappings
 func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 	var proto string
-	rawIP, hostPort, containerPort := splitParts(rawPort)
+	ip, hostPort, containerPort := splitParts(rawPort)
 	proto, containerPort = SplitProtoPort(containerPort)
 
-	// Strip [] from IPV6 addresses
-	ip, _, err := net.SplitHostPort(rawIP + ":")
-	if err != nil {
-		return nil, fmt.Errorf("Invalid ip address %v: %s", rawIP, err)
+	if ip != "" && ip[0] == '[' {
+		// Strip [] from IPV6 addresses
+		rawIP, _, err := net.SplitHostPort(ip + ":")
+		if err != nil {
+			return nil, fmt.Errorf("Invalid ip address %v: %s", ip, err)
+		}
+		ip = rawIP
 	}
 	if ip != "" && net.ParseIP(ip) == nil {
 		return nil, fmt.Errorf("Invalid ip address: %s", ip)

--- a/nat/nat_test.go
+++ b/nat/nat_test.go
@@ -201,42 +201,88 @@ func TestParsePortSpecFull(t *testing.T) {
 }
 
 func TestPartPortSpecIPV6(t *testing.T) {
-	portMappings, err := ParsePortSpec("[2001:4860:0:2001::68]::333")
-	if err != nil {
-		t.Fatalf("expected nil error, got: %v", err)
+	type test struct {
+		name     string
+		spec     string
+		expected []PortMapping
 	}
-
-	expected := []PortMapping{
+	cases := []test{
 		{
-			Port: "333/tcp",
-			Binding: PortBinding{
-				HostIP:   "2001:4860:0:2001::68",
-				HostPort: "",
+			name: "square angled IPV6 without host port",
+			spec: "[2001:4860:0:2001::68]::333",
+			expected: []PortMapping{
+				{
+					Port: "333/tcp",
+					Binding: PortBinding{
+						HostIP:   "2001:4860:0:2001::68",
+						HostPort: "",
+					},
+				},
+			},
+		},
+		{
+			name: "square angled IPV6 with host port",
+			spec: "[::1]:80:80",
+			expected: []PortMapping{
+				{
+					Port: "80/tcp",
+					Binding: PortBinding{
+						HostIP:   "::1",
+						HostPort: "80",
+					},
+				},
+			},
+		},
+		{
+			name: "IPV6 without host port",
+			spec: "2001:4860:0:2001::68::333",
+			expected: []PortMapping{
+				{
+					Port: "333/tcp",
+					Binding: PortBinding{
+						HostIP:   "2001:4860:0:2001::68",
+						HostPort: "",
+					},
+				},
+			},
+		},
+		{
+			name: "IPV6 with host port",
+			spec: "::1:80:80",
+			expected: []PortMapping{
+				{
+					Port: "80/tcp",
+					Binding: PortBinding{
+						HostIP:   "::1",
+						HostPort: "80",
+					},
+				},
+			},
+		},
+		{
+			name: ":: IPV6, without host port",
+			spec: "::::80",
+			expected: []PortMapping{
+				{
+					Port: "80/tcp",
+					Binding: PortBinding{
+						HostIP:   "::",
+						HostPort: "",
+					},
+				},
 			},
 		},
 	}
-	if !reflect.DeepEqual(expected, portMappings) {
-		t.Fatalf("wrong port mappings: got=%v, want=%v", portMappings, expected)
-	}
-}
-
-func TestPartPortSpecIPV6WithHostPort(t *testing.T) {
-	portMappings, err := ParsePortSpec("[::1]:80:80")
-	if err != nil {
-		t.Fatalf("expected nil error, got: %v", err)
-	}
-
-	expected := []PortMapping{
-		{
-			Port: "80/tcp",
-			Binding: PortBinding{
-				HostIP:   "::1",
-				HostPort: "80",
-			},
-		},
-	}
-	if !reflect.DeepEqual(expected, portMappings) {
-		t.Fatalf("wrong port mappings: got=%v, want=%v", portMappings, expected)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			portMappings, err := ParsePortSpec(c.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+			if !reflect.DeepEqual(c.expected, portMappings) {
+				t.Fatalf("wrong port mappings: got=%v, want=%v", portMappings, c.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
as discovered on https://github.com/docker/compose-cli/issues/1386:

docker-compose (docker-py) uses raw IPv6 for port specification, which go-connections reject as it relies on [net.SplitHostPort](https://golang.org/pkg/net/#SplitHostPort) which **require** square  bracets.

This PR relax requirement for square bracket, while still supporting those. I'll prepare another PR on docker-py to accepts and ignore square brackets, so both can be interoperable.

this is required to let IPV6 users (our own @chris-crone might not be the sole one) switch between docker-compose to docker<space>compose
