### PR TITLE
nat: remove deprecated PartParser()

### DIFF
--- a/nat/parse.go
+++ b/nat/parse.go
@@ -6,30 +6,6 @@ import (
 	"strings"
 )
 
-// PartParser parses and validates the specified string (data) using the specified template
-// e.g. ip:public:private -> 192.168.0.1:80:8000
-// DEPRECATED: do not use, this function may be removed in a future version
-func PartParser(template, data string) (map[string]string, error) {
-	// ip:public:private
-	var (
-		templateParts = strings.Split(template, ":")
-		parts         = strings.Split(data, ":")
-		out           = make(map[string]string, len(templateParts))
-	)
-	if len(parts) != len(templateParts) {
-		return nil, fmt.Errorf("Invalid format to parse. %s should match template %s", data, template)
-	}
-
-	for i, t := range templateParts {
-		value := ""
-		if len(parts) > i {
-			value = parts[i]
-		}
-		out[t] = value
-	}
-	return out, nil
-}
-
 // ParsePortRange parses and validates the specified string as a port-range (8000-9000)
 func ParsePortRange(ports string) (uint64, uint64, error) {
 	if ports == "" {


### PR DESCRIPTION
PartParser() was deprecated 5 Years ago in commit: https://github.com/docker/go-connections/commit/35dcbbc189523094211e7f0af23d862349ada334 (https://github.com/docker/go-connections/pull/19), which has been in releases v0.3.x and v0.4.x, so should now be fine to remove.
