### PR TITLE
revert "configureNpipeTransport: use winio.DialPipeContext()"

### DIFF
--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -4,7 +4,10 @@ package sockets
 import (
 	"errors"
 	"net/http"
+	"time"
 )
+
+const defaultTimeout = 10 * time.Second
 
 // ErrProtocolNotAvailable is returned when a given transport protocol is not provided by the operating system.
 var ErrProtocolNotAvailable = errors.New("protocol not available")

--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -11,10 +11,7 @@ import (
 	"time"
 )
 
-const (
-	defaultTimeout        = 10 * time.Second
-	maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
-)
+const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
 
 func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 	if len(addr) > maxUnixSocketPathSize {

--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -17,7 +17,12 @@ func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	// No need for compression in local communications.
 	tr.DisableCompression = true
 	tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
-		return winio.DialPipeContext(ctx, addr)
+		// DialPipeContext() has been added to winio:
+		// https://github.com/Microsoft/go-winio/commit/5fdbdcc2ae1c7e1073157fa7cb34a15eab472e1d
+		// However, a new version of winio with this commit has not been released yet.
+		// Continue to use DialPipe() until DialPipeContext() becomes available.
+		//return winio.DialPipeContext(ctx, addr)
+		return DialPipe(addr, defaultTimeout)
 	}
 	return nil
 }


### PR DESCRIPTION
This reverts https://github.com/docker/go-connections/pull/70, as it's possibly causing the failures as seen on https://github.com/moby/moby/pull/41084