### PR TITLE
ConfigureTransport: make sure a clean DialContext is used for tcp

### DIFF
--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -3,6 +3,7 @@ package sockets
 
 import (
 	"errors"
+	"net"
 	"net/http"
 	"time"
 )
@@ -24,6 +25,9 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 		return configureNpipeTransport(tr, proto, addr)
 	default:
 		tr.Proxy = http.ProxyFromEnvironment
+		tr.DialContext = (&net.Dialer{
+			Timeout: defaultTimeout,
+		}).DialContext
 	}
 	return nil
 }

--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -4,7 +4,10 @@ package sockets
 import (
 	"errors"
 	"net/http"
+	"time"
 )
+
+const defaultTimeout = 10 * time.Second
 
 // ErrProtocolNotAvailable is returned when a given transport protocol is not provided by the operating system.
 var ErrProtocolNotAvailable = errors.New("protocol not available")

--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -11,10 +11,7 @@ import (
 	"time"
 )
 
-const (
-	defaultTimeout        = 10 * time.Second
-	maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
-)
+const maxUnixSocketPathSize = len(syscall.RawSockaddrUnix{}.Path)
 
 func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 	if len(addr) > maxUnixSocketPathSize {


### PR DESCRIPTION
- Fixes https://github.com/docker/go-connections/issues/99

Since #61, there's no more DialContext defined in the default switch case of ConfigureTransport. As a consequence, if ConfigureTransport was already called with a npipe or unix proto (ie. Docker client does that to initialize its HTTP client with the default DOCKER_HOST), the DialContext function defined by these protocols will be used.

As the DialContext functions defined by unix and npipe protos totally ignore DialContext's 2nd and 3rd argument (ie. network and addr) and instead use the equivalent arguments passed to configureUnixTransport and configureNpipeTransport when they were called, this results in ConfigureTransport being totally ineffective.

In addition, DisableCompression is also reset to false.