### PR TITLE
sockets: deprecate DialerFromEnvironment, GetProxyEnv

### DIFF
--- a/sockets/proxy.go
+++ b/sockets/proxy.go
@@ -9,6 +9,8 @@ import (
 // GetProxyEnv allows access to the uppercase and the lowercase forms of
 // proxy-related variables.  See the Go specification for details on these
 // variables. https://golang.org/pkg/net/http/
+//
+// Deprecated: this function was used as helper for [DialerFromEnvironment] and is no longer used. It will be removed in the next release.
 func GetProxyEnv(key string) string {
 	proxyValue := os.Getenv(strings.ToUpper(key))
 	if proxyValue == "" {
@@ -19,10 +21,11 @@ func GetProxyEnv(key string) string {
 
 // DialerFromEnvironment was previously used to configure a net.Dialer to route
 // connections through a SOCKS proxy.
-// DEPRECATED: SOCKS proxies are now supported by configuring only
+//
+// Deprecated: SOCKS proxies are now supported by configuring only
 // http.Transport.Proxy, and no longer require changing http.Transport.Dial.
-// Therefore, only sockets.ConfigureTransport() needs to be called, and any
-// sockets.DialerFromEnvironment() calls can be dropped.
+// Therefore, only [sockets.ConfigureTransport] needs to be called, and any
+// [sockets.DialerFromEnvironment] calls can be dropped.
 func DialerFromEnvironment(direct *net.Dialer) (*net.Dialer, error) {
 	return direct, nil
 }


### PR DESCRIPTION
DialerFromEnvironment was already deprecated, but the format of the deprecation message was incorrect, so didn't get marked as such.

Also deprecate GetProxyEnv, which is no longer used.


With this patch:

<img width="1384" alt="Screenshot 2025-04-24 at 10 10 20" src="https://github.com/user-attachments/assets/140af8cf-e35b-49e4-8ace-e18ae83cab9e" />


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

