### PR TITLE
proxy: clientLoop; improve handling of closed pipes

### DIFF
--- a/proxy/proxy_unix.go
+++ b/proxy/proxy_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package proxy
+
+import "syscall"
+
+// errConnReset is the platform-specific "connection reset by peer".
+const errConnReset = syscall.ECONNRESET

--- a/proxy/proxy_windows.go
+++ b/proxy/proxy_windows.go
@@ -1,0 +1,10 @@
+package proxy
+
+import (
+	"syscall"
+)
+
+// errConnReset is the platform-specific "connection reset by peer".
+//
+// https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2#wsaeconnreset
+const errConnReset = syscall.WSAECONNRESET

--- a/proxy/tcp_proxy.go
+++ b/proxy/tcp_proxy.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"io"
 	"net"
 	"syscall"
@@ -51,7 +52,7 @@ func (proxy *TCPProxy) clientLoop(client *net.TCPConn, quit chan bool) {
 		if err != nil {
 			// If the socket we are writing to is shutdown with
 			// SHUT_WR, forward it to the other end of the pipe:
-			if err, ok := err.(*net.OpError); ok && err.Err == syscall.EPIPE {
+			if errors.Is(err, syscall.EPIPE) || errors.Is(err, errConnReset) {
 				_ = from.CloseRead()
 			}
 		}


### PR DESCRIPTION
- relates to / closes https://github.com/docker/go-connections/issues/110

---

- use errors.Is to make sure we unwrap errors
- also handle "syscall.WSAECONNRESET" (windows), and "syscall.ECONNRESET" (other platforms).


**- A picture of a cute animal (not mandatory but encouraged)**

