### PR TITLE
tlsconfig: remove uses of PreferServerCipherSuites

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -53,9 +53,8 @@ var DefaultServerAcceptedCiphers = append(clientCipherSuites, acceptedCBCCiphers
 func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
 	tlsConfig := &tls.Config{
 		// Avoid fallback by default to SSL protocols < TLS1.2
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
-		CipherSuites:             DefaultServerAcceptedCiphers,
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: DefaultServerAcceptedCiphers,
 	}
 
 	for _, op := range ops {

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -127,9 +127,6 @@ func TestConfigServerTLSServerCertsOnly(t *testing.T) {
 	if !reflect.DeepEqual(tlsConfig.CipherSuites, DefaultServerAcceptedCiphers) {
 		t.Fatal("Unexpected server cipher suites")
 	}
-	if !tlsConfig.PreferServerCipherSuites { //nolint:staticcheck // Ignore SA1019: tlsConfig.PreferServerCipherSuites has been deprecated since Go 1.18: PreferServerCipherSuites is ignored.
-		t.Fatal("Expected server to prefer cipher suites")
-	}
 	if tlsConfig.MinVersion != tls.VersionTLS12 {
 		t.Fatal("Unexpected server TLS version")
 	}


### PR DESCRIPTION
This field was deprecated in [go1.17beta1], and is no longer used, so we can remove its use, as the minimum go version in go.mod is go1.18.

[go1.17beta1]: https://github.com/golang/go/commit/9d0819b27ca248f9949e7cf6bf7cb9fe7cf574e8


**- A picture of a cute animal (not mandatory but encouraged)**

