### PR TITLE
socket: deprecate DialPipe

### DIFF
--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -42,6 +42,14 @@ func ConfigureTransport(tr *http.Transport, proto, addr string) error {
 	return nil
 }
 
+// DialPipe connects to a Windows named pipe. It is not supported on
+// non-Windows platforms.
+//
+// Deprecated: use [github.com/Microsoft/go-winio.DialPipe] or [github.com/Microsoft/go-winio.DialPipeContext].
+func DialPipe(addr string, timeout time.Duration) (net.Conn, error) {
+	return dialPipe(addr, timeout)
+}
+
 func configureUnixTransport(tr *http.Transport, proto, addr string) error {
 	if len(addr) > maxUnixSocketPathSize {
 		return fmt.Errorf("unix socket path %q is too long", addr)

--- a/sockets/sockets_unix.go
+++ b/sockets/sockets_unix.go
@@ -13,8 +13,6 @@ func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	return ErrProtocolNotAvailable
 }
 
-// DialPipe connects to a Windows named pipe.
-// This is not supported on other OSes.
-func DialPipe(_ string, _ time.Duration) (net.Conn, error) {
+func dialPipe(_ string, _ time.Duration) (net.Conn, error) {
 	return nil, syscall.EAFNOSUPPORT
 }

--- a/sockets/sockets_windows.go
+++ b/sockets/sockets_windows.go
@@ -18,7 +18,6 @@ func configureNpipeTransport(tr *http.Transport, proto, addr string) error {
 	return nil
 }
 
-// DialPipe connects to a Windows named pipe.
-func DialPipe(addr string, timeout time.Duration) (net.Conn, error) {
+func dialPipe(addr string, timeout time.Duration) (net.Conn, error) {
 	return winio.DialPipe(addr, &timeout)
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50125

This function was a wrapper for go-winio.DialPipe. Deprecate it in favor of using that package directly.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

