### PR TITLE
sockets: ConfigureTransport: prevent idle connections leaking FDs

### DIFF
--- a/sockets/sockets.go
+++ b/sockets/sockets.go
@@ -27,6 +27,14 @@ var ErrProtocolNotAvailable = errors.New("protocol not available")
 // make sure you do it _after_ any subsequent calls to ConfigureTransport is made against the same
 // [http.Transport].
 func ConfigureTransport(tr *http.Transport, proto, addr string) error {
+	if tr.MaxIdleConns == 0 {
+		// prevent long-lived processes from leaking connections
+		// due to idle connections not being released.
+		//
+		// TODO: see if we can also address this from the server side; see: https://github.com/moby/moby/issues/45539
+		tr.MaxIdleConns = 6
+		tr.IdleConnTimeout = 30 * time.Second
+	}
 	switch proto {
 	case "unix":
 		return configureUnixTransport(tr, proto, addr)


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48736
- https://github.com/moby/moby/issues/45539


Set default `MaxIdleConns` / `IdleConnTimeout` to prevent idle connections leaking FDs.

When using the client (initialized via `dockercli` in my case) in a long-running process, the idle connections are not released. If you create multiple clients the FD count keeps growing indefinitely.

This can be demonstrated against Docker Desktop; other cases have not been tested, but it also depends on the server's behavior and when the server will drop the connections.

Other possible fixes could be:

- initialize transport from DefaultTransport (that has better defaults)
- Somehow wrap transport so all clients use the same keepalive pool
- Make this configurable. I would also need dockerCLI update then.
- Explore server side
- There is a call to `CloseIdleConns` but that lifecycle is tricky to manage when initializing clients via `dockerCLI` based on multiple configs. Possibly defining a `Finalizer` could also result in the desired behavior.

This patch migrates the code from [moby@5c72a95] to this module.

[moby@5c72a95]: https://github.com/moby/moby/commit/5c72a95a30bb1a1c5cdb2ad555dd1bc0622cf870


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
sockets: ConfigureTransport: prevent idle connections leaking FDs
```


**- A picture of a cute animal (not mandatory but encouraged)**

