### PR TITLE
sockets: implement WithAdditionalUsersAndGroups for windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/docker/go-connections
 
 go 1.18
 
-require github.com/Microsoft/go-winio v0.4.21
-
-require golang.org/x/sys v0.1.0 // indirect
+require (
+	github.com/Microsoft/go-winio v0.4.21
+	golang.org/x/sys v0.1.0
+)

--- a/sockets/unix_socket_windows.go
+++ b/sockets/unix_socket_windows.go
@@ -1,7 +1,137 @@
 package sockets
 
-import "net"
+import (
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
 
-func listenUnix(path string) (net.Listener, error) {
-	return net.Listen("unix", path)
+	"github.com/Microsoft/go-winio"
+	"golang.org/x/sys/windows"
+)
+
+// BasePermissions defines the default DACL, which allows Administrators
+// and LocalSystem full access (similar to defaults used in [moby]);
+//
+// - D:P: DACL without inheritance (protected, (P)).
+// - (A;;GA;;;BA): Allow full access (GA) for built-in Administrators (BA).
+// - (A;;GA;;;SY); Allow full access (GA) for LocalSystem (SY).
+// - Any other user is denied access.
+//
+// [moby]: https://github.com/moby/moby/blob/6b45c76a233b1b8b56465f76c21c09fd7920e82d/daemon/listeners/listeners_windows.go#L53-L59
+const BasePermissions = "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
+
+// WithBasePermissions sets a default DACL, which allows Administrators
+// and LocalSystem full access (similar to defaults used in [moby]);
+//
+// - D:P: DACL without inheritance (protected, (P)).
+// - (A;;GA;;;BA): Allow full access (GA) for built-in Administrators (BA).
+// - (A;;GA;;;SY); Allow full access (GA) for LocalSystem (SY).
+// - Any other user is denied access.
+//
+// [moby]: https://github.com/moby/moby/blob/6b45c76a233b1b8b56465f76c21c09fd7920e82d/daemon/listeners/listeners_windows.go#L53-L59
+func WithBasePermissions() SockOption {
+	return withSDDL(BasePermissions)
+}
+
+// WithAdditionalUsersAndGroups modifies the socket file's DACL to grant
+// access to additional users and groups.
+//
+// It sets [BasePermissions] on the socket path and grants the given additional
+// users and groups to generic read (GR) and write (GW) access. It returns
+// an error if no groups were given, when failing to resolve any of the
+// additional users and groups, or when failing to apply the ACL.
+func WithAdditionalUsersAndGroups(additionalUsersAndGroups []string) SockOption {
+	return func(path string) error {
+		if len(additionalUsersAndGroups) == 0 {
+			return errors.New("no additional users specified")
+		}
+		sd, err := getSecurityDescriptor(additionalUsersAndGroups...)
+		if err != nil {
+			return fmt.Errorf("looking up SID: %w", err)
+		}
+		return withSDDL(sd)(path)
+	}
+}
+
+// withSDDL applies the given SDDL to the socket. It returns an error
+// when failing parse the SDDL, or if the DACL was defaulted.
+//
+// TODO(thaJeztah); this is not exported yet, as some of the checks may need review if they're not too opinionated.
+func withSDDL(sddl string) SockOption {
+	return func(path string) error {
+		sd, err := windows.SecurityDescriptorFromString(sddl)
+		if err != nil {
+			return fmt.Errorf("parsing SDDL: %w", err)
+		}
+		dacl, defaulted, err := sd.DACL()
+		if err != nil {
+			return fmt.Errorf("extracting DACL: %w", err)
+		}
+		if dacl == nil || defaulted {
+			// should never be hit with our [DefaultPermissions],
+			// as it contains "D:" and "P" (protected, don't inherit).
+			return errors.New("no DACL found in security descriptor or defaulted")
+		}
+		return windows.SetNamedSecurityInfo(
+			path,
+			windows.SE_FILE_OBJECT,
+			windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION,
+			nil, // do not change the owner
+			nil, // do not change the owner
+			dacl,
+			nil,
+		)
+	}
+}
+
+// NewUnixSocket creates a new unix socket.
+//
+// It sets [BasePermissions] on the socket path and grants the given additional
+// users and groups to generic read (GR) and write (GW) access. It returns
+// an error when failing to resolve any of the additional users and groups,
+// or when failing to apply the ACL.
+func NewUnixSocket(path string, additionalUsersAndGroups []string) (net.Listener, error) {
+	var opts []SockOption
+	if len(additionalUsersAndGroups) > 0 {
+		opts = append(opts, WithAdditionalUsersAndGroups(additionalUsersAndGroups))
+	} else {
+		opts = append(opts, WithBasePermissions())
+	}
+	return NewUnixSocketWithOpts(path, opts...)
+}
+
+// getSecurityDescriptor returns the DACL for the Unix socket.
+//
+// By default, it grants [BasePermissions], but allows for additional
+// users and groups to get generic read (GR) and write (GW) access. It
+// returns an error when failing to resolve any of the additional users
+// and groups.
+func getSecurityDescriptor(additionalUsersAndGroups ...string) (string, error) {
+	sddl := BasePermissions
+
+	// Grant generic read (GR) and write (GW) access to whatever
+	// additional users or groups were specified.
+	//
+	// TODO(thaJeztah): should we fail on, or remove duplicates?
+	for _, g := range additionalUsersAndGroups {
+		sid, err := winio.LookupSidByName(strings.TrimSpace(g))
+		if err != nil {
+			return "", fmt.Errorf("looking up SID: %w", err)
+		}
+		sddl += fmt.Sprintf("(A;;GRGW;;;%s)", sid)
+	}
+	return sddl, nil
+}
+
+func listenUnix(socketPath string) (net.Listener, error) {
+	socketPath = filepath.ToSlash(socketPath)
+	if len(socketPath) >= 2 && socketPath[1] == ':' {
+		socketPath = socketPath[2:] // strip drive-letter (e.g., "C:").
+		if !strings.HasPrefix(socketPath, "/") {
+			socketPath = "/" + socketPath
+		}
+	}
+	return net.Listen("unix", socketPath)
 }

--- a/sockets/unix_socket_windows_test.go
+++ b/sockets/unix_socket_windows_test.go
@@ -2,8 +2,63 @@ package sockets
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestGetSecurityDescriptor(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		sddl, err := getSecurityDescriptor()
+		if err != nil {
+			t.Error(err)
+		}
+		expected := BasePermissions
+		if sddl != expected {
+			t.Errorf("expected: %s, got: %s", expected, sddl)
+		}
+	})
+	t.Run("Users", func(t *testing.T) {
+		const name = "Users" // for testing, should always be available
+		sddl, err := getSecurityDescriptor(name)
+		if err != nil {
+			t.Error(err)
+		}
+		// FIXME(thaJeztah): this may not be a reproducible SID; probably should do some fuzzy matching.
+		const expected = "D:P(A;;GA;;;BA)(A;;GA;;;SY)(A;;GRGW;;;S-1-5-32-545)"
+		if sddl != expected {
+			t.Errorf("expected: %s, got: %s", expected, sddl)
+		}
+	})
+
+	// TODO(thaJeztah): should this fail on duplicate users?
+	t.Run("Users twice", func(t *testing.T) {
+		const name = "Users" // for testing, should always be available
+		sddl, err := getSecurityDescriptor(name, name)
+		if err != nil {
+			t.Error(err)
+		}
+		// FIXME(thaJeztah): this may not be a reproducible SID; probably should do some fuzzy matching.
+		const expected = "D:P(A;;GA;;;BA)(A;;GA;;;SY)(A;;GRGW;;;S-1-5-32-545)(A;;GRGW;;;S-1-5-32-545)"
+		if sddl != expected {
+			t.Errorf("expected: %s, got: %s", expected, sddl)
+		}
+	})
+	t.Run("NoSuchUserOrGroup", func(t *testing.T) {
+		const name = "NoSuchUserOrGroup" // non-existing user or group
+		sddl, err := getSecurityDescriptor(name)
+		if sddl != "" {
+			t.Errorf("expected an empty sddl, got: %s", sddl)
+		}
+		if err == nil {
+			t.Error("expected error")
+		}
+
+		const expected = "looking up SID: lookup account NoSuchUserOrGroup: not found"
+		if errMsg := err.Error(); errMsg != expected {
+			t.Errorf("expected: %s, got: %s", expected, errMsg)
+		}
+	})
+}
 
 func TestUnixSocketWithOpts(t *testing.T) {
 	socketFile, err := os.CreateTemp("", "test*.sock")
@@ -21,4 +76,28 @@ func TestUnixSocketWithOpts(t *testing.T) {
 
 	echoStr := "hello"
 	runTest(t, socketFile.Name(), l, echoStr)
+}
+
+func TestNewUnixSocket(t *testing.T) {
+	group := "Users" // for testing, should always be available
+	socketPath := filepath.Join(os.TempDir(), "test.sock")
+	defer func() { _ = os.Remove(socketPath) }()
+	t.Logf("socketPath: %s, path length: %d", socketPath, len(socketPath))
+
+	l, err := NewUnixSocket(socketPath, []string{group})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = l.Close() }()
+	runTest(t, socketPath, l, "hello")
+}
+
+func TestNewUnixSocketUnknownGroup(t *testing.T) {
+	group := "NoSuchUserOrGroup"
+	socketPath := filepath.Join(os.TempDir(), "fail.sock")
+	_, err := NewUnixSocket(socketPath, []string{group})
+	_ = os.Remove(socketPath)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
 }


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/go-connections/pull/138

----

- Implement a WithAdditionalUsersAndGroups (windows daemon allows
  specifying multiple additional users and groups for named pipes
  and unix-sockets).
- Implement NewUnixSocket that accepts (optional) additional users
  and groups.

Partially based on https://github.com/moby/moby/blob/6b45c76a233b1b8b56465f76c21c09fd7920e82d/daemon/listeners/listeners_windows.go#L53-L80

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

