### PR TITLE
check for net.ErrClosed instead of "use of closed network connection"

### DIFF
--- a/sockets/inmem_socket_test.go
+++ b/sockets/inmem_socket_test.go
@@ -1,6 +1,10 @@
 package sockets
 
-import "testing"
+import (
+	"errors"
+	"net"
+	"testing"
+)
 
 func TestInmemSocket(t *testing.T) {
 	l := NewInmemSocket("test", 0)
@@ -33,7 +37,7 @@ func TestInmemSocket(t *testing.T) {
 
 	_ = l.Close()
 	_, err = l.Dial("test", "test")
-	if err != errClosed {
-		t.Fatalf("expected `errClosed` error, got %v", err)
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf(`expected "net.ErrClosed" error, got %[1]v (%[1]T)`, err)
 	}
 }


### PR DESCRIPTION
The infamous "use of closed network connection" error was added in [cl-5649076] as a non-exported error. This made it not possible to write code to handle it as a sentinel error, other than through string- matching.

Commit [moby@cc851db] (docker v0.6.4) added a [`IsClosedError`] utility for this (as [net.errClosing@go1.1.2] did not yet export this error). The `IsClosedError` was later moved to the `go-connections` module, but various other places in our code used similar matching.

There was a feature-request [go-4373] to export it, which got accepted and implemented in [CL 5649076], so starting with go1.16 we now have [net.ErrClosed@go1.16], so can remove the string matching.

[CL 5649076]: https://golang.org/cl/5649076
[moby@cc851db]: https://github.com/moby/moby/commit/cc851dbb3f4725562729f12663e246690a61c620
[`IsClosedError`]: https://github.com/moby/moby/blob/cc851dbb3f4725562729f12663e246690a61c620/utils/utils.go#L1032-L1040
[net.errClosing@go1.1.2]: https://github.com/golang/go/blob/go1.1.2/src/pkg/net/net.go#L341
[go-4373]: https://github.com/golang/go/issues/4373
[net.ErrClosed@go1.16]: https://github.com/golang/go/blob/go1.16/src/net/net.go#L636-L645

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

