### PR TITLE
nat: ParsePortSpec: validate port before proto

### DIFF
--- a/nat/nat.go
+++ b/nat/nat.go
@@ -173,6 +173,10 @@ func splitParts(rawport string) (hostIP, hostPort, containerPort string) {
 func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 	ip, hostPort, containerPort := splitParts(rawPort)
 	proto, containerPort := SplitProtoPort(containerPort)
+	if containerPort == "" {
+		return nil, fmt.Errorf("no port specified: %s<empty>", rawPort)
+	}
+
 	proto = strings.ToLower(proto)
 	if err := validateProto(proto); err != nil {
 		return nil, err
@@ -188,9 +192,6 @@ func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 	}
 	if ip != "" && net.ParseIP(ip) == nil {
 		return nil, errors.New("invalid IP address: " + ip)
-	}
-	if containerPort == "" {
-		return nil, fmt.Errorf("no port specified: %s<empty>", rawPort)
 	}
 
 	startPort, endPort, err := ParsePortRange(containerPort)

--- a/nat/nat_test.go
+++ b/nat/nat_test.go
@@ -241,6 +241,38 @@ func TestSplitProtoPort(t *testing.T) {
 	}
 }
 
+func TestParsePortSpecEmptyContainerPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     string
+		expError string
+	}{
+		{
+			name:     "empty spec",
+			spec:     "",
+			expError: `no port specified: <empty>`,
+		},
+		{
+			name:     "empty container port",
+			spec:     `0.0.0.0:1234-1235:/tcp`,
+			expError: `no port specified: 0.0.0.0:1234-1235:/tcp<empty>`,
+		},
+		{
+			name:     "empty container port and proto",
+			spec:     `0.0.0.0:1234-1235:`,
+			expError: `no port specified: 0.0.0.0:1234-1235:<empty>`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParsePortSpec(tc.spec)
+			if err == nil || err.Error() != tc.expError {
+				t.Fatalf("expected %v, got: %v", tc.expError, err)
+			}
+		})
+	}
+}
+
 func TestParsePortSpecFull(t *testing.T) {
 	portMappings, err := ParsePortSpec("0.0.0.0:1234-1235:3333-3334/tcp")
 	if err != nil {


### PR DESCRIPTION
relates to:

- https://github.com/docker/go-connections/pull/121
- https://github.com/docker/cli/pull/6250#discussion_r2264014778


commit f38822229cbe4b84304ffb166160b6a253938009 made an optimization to handle validating the proto before parsing port-numbers, but as a result changed the error returned if the port was missing.

This patch moves the check for empty container ports to the start to keep the old behavior. The error-message(s) can probably be improved a bit, but this keeps the existing output.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

