### PR TITLE
nat: cleanup, optimize, and improve errors 

### DIFF
--- a/nat/nat.go
+++ b/nat/nat.go
@@ -55,15 +55,12 @@ func ParsePort(rawPort string) (int, error) {
 }
 
 // ParsePortRangeToInt parses the port range string and returns start/end ints
-func ParsePortRangeToInt(rawPort string) (int, int, error) {
+func ParsePortRangeToInt(rawPort string) (startPort, endPort int, _ error) {
 	if rawPort == "" {
+		// TODO(thaJeztah): consider making this an error; this was kept to keep existing behavior.
 		return 0, 0, nil
 	}
-	start, end, err := ParsePortRange(rawPort)
-	if err != nil {
-		return 0, 0, err
-	}
-	return int(start), int(end), nil
+	return parsePortRange(rawPort)
 }
 
 // Proto returns the protocol of a Port

--- a/nat/nat.go
+++ b/nat/nat.go
@@ -61,28 +61,35 @@ func ParsePortRangeToInt(rawPort string) (startPort, endPort int, _ error) {
 
 // Proto returns the protocol of a Port
 func (p Port) Proto() string {
-	proto, _ := SplitProtoPort(string(p))
+	_, proto, _ := strings.Cut(string(p), "/")
+	if proto == "" {
+		proto = "tcp"
+	}
 	return proto
 }
 
 // Port returns the port number of a Port
 func (p Port) Port() string {
-	_, port := SplitProtoPort(string(p))
+	port, _, _ := strings.Cut(string(p), "/")
 	return port
 }
 
-// Int returns the port number of a Port as an int
+// Int returns the port number of a Port as an int. It assumes [Port]
+// is valid, and returns 0 otherwise.
 func (p Port) Int() int {
-	portStr := p.Port()
 	// We don't need to check for an error because we're going to
-	// assume that any error would have been found, and reported, in NewPort()
-	port, _ := ParsePort(portStr)
+	// assume that any error would have been found, and reported, in [NewPort]
+	port, _ := parsePortNumber(p.Port())
 	return port
 }
 
 // Range returns the start/end port numbers of a Port range as ints
 func (p Port) Range() (int, int, error) {
-	return ParsePortRangeToInt(p.Port())
+	portRange := p.Port()
+	if portRange == "" {
+		return 0, 0, nil
+	}
+	return parsePortRange(portRange)
 }
 
 // SplitProtoPort splits a port(range) and protocol, formatted as "<portnum>/[<proto>]"

--- a/nat/nat.go
+++ b/nat/nat.go
@@ -27,19 +27,15 @@ type PortSet map[Port]struct{}
 type Port string
 
 // NewPort creates a new instance of a Port given a protocol and port number or port range
-func NewPort(proto, port string) (Port, error) {
-	// Check for parsing issues on "port" now so we can avoid having
-	// to check it later on.
-
-	portStartInt, portEndInt, err := ParsePortRangeToInt(port)
+func NewPort(proto, portOrRange string) (Port, error) {
+	start, end, err := parsePortRange(portOrRange)
 	if err != nil {
 		return "", err
 	}
-
-	if portStartInt == portEndInt {
-		return Port(fmt.Sprintf("%d/%s", portStartInt, proto)), nil
+	if start == end {
+		return Port(fmt.Sprintf("%d/%s", start, proto)), nil
 	}
-	return Port(fmt.Sprintf("%d-%d/%s", portStartInt, portEndInt, proto)), nil
+	return Port(fmt.Sprintf("%d-%d/%s", start, end, proto)), nil
 }
 
 // ParsePort parses the port number string and returns an int

--- a/nat/nat.go
+++ b/nat/nat.go
@@ -186,14 +186,14 @@ func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 		return nil, fmt.Errorf("no port specified: %s<empty>", rawPort)
 	}
 
-	startPort, endPort, err := ParsePortRange(containerPort)
+	startPort, endPort, err := parsePortRange(containerPort)
 	if err != nil {
 		return nil, errors.New("invalid containerPort: " + containerPort)
 	}
 
-	var startHostPort, endHostPort uint64
+	var startHostPort, endHostPort int
 	if hostPort != "" {
-		startHostPort, endHostPort, err = ParsePortRange(hostPort)
+		startHostPort, endHostPort, err = parsePortRange(hostPort)
 		if err != nil {
 			return nil, errors.New("invalid hostPort: " + hostPort)
 		}
@@ -210,19 +210,18 @@ func ParsePortSpec(rawPort string) ([]PortMapping, error) {
 	count := endPort - startPort + 1
 	ports := make([]PortMapping, 0, count)
 
-	for i := uint64(0); i < count; i++ {
-		cPort := Port(strconv.FormatUint(startPort+i, 10) + "/" + proto)
+	for i := 0; i < count; i++ {
 		hPort := ""
 		if hostPort != "" {
-			hPort = strconv.FormatUint(startHostPort+i, 10)
+			hPort = strconv.Itoa(startHostPort + i)
 			// Set hostPort to a range only if there is a single container port
 			// and a dynamic host port.
 			if count == 1 && startHostPort != endHostPort {
-				hPort += "-" + strconv.FormatUint(endHostPort, 10)
+				hPort += "-" + strconv.Itoa(endHostPort)
 			}
 		}
 		ports = append(ports, PortMapping{
-			Port:    cPort,
+			Port:    Port(strconv.Itoa(startPort+i) + "/" + proto),
 			Binding: PortBinding{HostIP: ip, HostPort: hPort},
 		})
 	}

--- a/nat/nat.go
+++ b/nat/nat.go
@@ -47,11 +47,11 @@ func ParsePort(rawPort string) (int, error) {
 	if rawPort == "" {
 		return 0, nil
 	}
-	port, err := strconv.ParseUint(rawPort, 10, 16)
+	port, err := parsePortNumber(rawPort)
 	if err != nil {
-		return 0, fmt.Errorf("invalid port '%s': %w", rawPort, errors.Unwrap(err))
+		return 0, fmt.Errorf("invalid port '%s': %w", rawPort, err)
 	}
-	return int(port), nil
+	return port, nil
 }
 
 // ParsePortRangeToInt parses the port range string and returns start/end ints

--- a/nat/nat_test.go
+++ b/nat/nat_test.go
@@ -38,7 +38,7 @@ func TestParsePort(t *testing.T) {
 			doc:     "negative value",
 			input:   "-1",
 			expPort: 0,
-			expErr:  `invalid port '-1': invalid syntax`,
+			expErr:  `invalid port '-1': value out of range (0–65535)`,
 		},
 		// FIXME currently this is a valid port. I don't think it should be.
 		// I'm leaving this test until we make a decision.
@@ -57,7 +57,7 @@ func TestParsePort(t *testing.T) {
 			doc:     "value out of range",
 			input:   "65536",
 			expPort: 0,
-			expErr:  `invalid port '65536': value out of range`,
+			expErr:  `invalid port '65536': value out of range (0–65535)`,
 		},
 	}
 

--- a/nat/nat_test.go
+++ b/nat/nat_test.go
@@ -675,11 +675,11 @@ func TestParseNetworkOptsNegativePorts(t *testing.T) {
 		t.Fail()
 	}
 	if len(ports) != 0 {
-		t.Logf("Expected nil got %d", len(ports))
+		t.Logf("Expected 0 got %d: %#v", len(ports), ports)
 		t.Fail()
 	}
 	if len(bindings) != 0 {
-		t.Logf("Expected 0 got %d", len(bindings))
+		t.Logf("Expected 0 got %d: %#v", len(bindings), bindings)
 		t.Fail()
 	}
 }
@@ -690,11 +690,11 @@ func TestParseNetworkOptsUdp(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(ports) != 1 {
-		t.Logf("Expected 1 got %d", len(ports))
+		t.Logf("Expected 1 got %d: %#v", len(ports), ports)
 		t.FailNow()
 	}
 	if len(bindings) != 1 {
-		t.Logf("Expected 1 got %d", len(bindings))
+		t.Logf("Expected 1 got %d: %#v", len(bindings), bindings)
 		t.FailNow()
 	}
 	for k := range ports {
@@ -732,11 +732,11 @@ func TestParseNetworkOptsSctp(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(ports) != 1 {
-		t.Logf("Expected 1 got %d", len(ports))
+		t.Logf("Expected 1 got %d: %#v", len(ports), ports)
 		t.FailNow()
 	}
 	if len(bindings) != 1 {
-		t.Logf("Expected 1 got %d", len(bindings))
+		t.Logf("Expected 1 got %d: %#v", len(bindings), bindings)
 		t.FailNow()
 	}
 	for k := range ports {

--- a/nat/parse.go
+++ b/nat/parse.go
@@ -31,3 +31,24 @@ func ParsePortRange(ports string) (uint64, uint64, error) {
 	}
 	return start, end, nil
 }
+
+// parsePortNumber parses rawPort into an int, unwrapping strconv errors
+// and returning a single "out of range" error for any value outside 0–65535.
+func parsePortNumber(rawPort string) (int, error) {
+	if rawPort == "" {
+		return 0, errors.New("value is empty")
+	}
+	port, err := strconv.ParseInt(rawPort, 10, 0)
+	if err != nil {
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) {
+			err = numErr.Err
+		}
+		return 0, err
+	}
+	if port < 0 || port > 65535 {
+		return 0, errors.New("value out of range (0–65535)")
+	}
+
+	return int(port), nil
+}

--- a/nat/parse_test.go
+++ b/nat/parse_test.go
@@ -120,3 +120,85 @@ func TestParsePortRange(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePortNumber(t *testing.T) {
+	tests := []struct {
+		doc    string
+		input  string
+		exp    int
+		expErr string
+	}{
+		{
+			doc:    "empty string",
+			input:  "",
+			expErr: "value is empty",
+		},
+		{
+			doc:    "whitespace only",
+			input:  "   ",
+			expErr: "invalid syntax",
+		},
+		{
+			doc:   "single valid port",
+			input: "1234",
+			exp:   1234,
+		},
+		{
+			doc:   "zero port",
+			input: "0",
+			exp:   0,
+		},
+		{
+			doc:   "max valid port",
+			input: "65535",
+			exp:   65535,
+		},
+		{
+			doc:    "leading/trailing spaces",
+			input:  "  42  ",
+			expErr: "invalid syntax",
+		},
+		{
+			doc:    "negative port",
+			input:  "-1",
+			expErr: "value out of range (0–65535)",
+		},
+		{
+			doc:    "too large port",
+			input:  "70000",
+			expErr: "value out of range (0–65535)",
+		},
+		{
+			doc:    "non-numeric",
+			input:  "foo",
+			expErr: "invalid syntax",
+		},
+		{
+			doc:    "trailing garbage",
+			input:  "1234abc",
+			expErr: "invalid syntax",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			got, err := parsePortNumber(tc.input)
+
+			if tc.expErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.exp {
+					t.Errorf("expected %d, got %d", tc.exp, got)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tc.expErr)
+				}
+				if err.Error() != tc.expErr {
+					t.Errorf("expected error %q, got %q", tc.expErr, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/nat/parse_test.go
+++ b/nat/parse_test.go
@@ -50,52 +50,52 @@ func TestParsePortRange(t *testing.T) {
 		{
 			doc:    "non-numeric port",
 			input:  "asdf",
-			expErr: `strconv.ParseUint: parsing "asdf": invalid syntax`,
+			expErr: `invalid start port 'asdf': invalid syntax`,
 		},
 		{
 			doc:    "reversed range",
 			input:  "9000-8000",
-			expErr: `invalid range specified for port: 9000-8000`,
+			expErr: `invalid port range: 9000-8000`,
 		},
 		{
 			doc:    "range missing end",
 			input:  "8000-",
-			expErr: `strconv.ParseUint: parsing "": invalid syntax`,
+			expErr: `invalid end port '': value is empty`,
 		},
 		{
 			doc:    "range missing start",
 			input:  "-9000",
-			expErr: `strconv.ParseUint: parsing "": invalid syntax`,
+			expErr: `invalid start port '': value is empty`,
 		},
 		{
 			doc:    "invalid range end",
 			input:  "8000-a",
-			expErr: `strconv.ParseUint: parsing "a": invalid syntax`,
+			expErr: `invalid end port 'a': invalid syntax`,
 		},
 		{
 			doc:    "invalid range end port",
 			input:  "8000-9000a",
-			expErr: `strconv.ParseUint: parsing "9000a": invalid syntax`,
+			expErr: `invalid end port '9000a': invalid syntax`,
 		},
 		{
 			doc:    "range range start",
 			input:  "a-9000",
-			expErr: `strconv.ParseUint: parsing "a": invalid syntax`,
+			expErr: `invalid start port 'a': invalid syntax`,
 		},
 		{
 			doc:    "range range start port",
 			input:  "8000a-9000",
-			expErr: `strconv.ParseUint: parsing "8000a": invalid syntax`,
+			expErr: `invalid start port '8000a': invalid syntax`,
 		},
 		{
 			doc:    "range with trailing hyphen",
 			input:  "-8000-",
-			expErr: `strconv.ParseUint: parsing "": invalid syntax`,
+			expErr: `invalid start port '': value is empty`,
 		},
 		{
 			doc:    "range without ports",
 			input:  "-",
-			expErr: `strconv.ParseUint: parsing "": invalid syntax`,
+			expErr: `invalid start port '': value is empty`,
 		},
 	}
 


### PR DESCRIPTION
### nat: improve some assertions

### nat: add parsePortNumber utility

Add a utility for parsing and validating port-numbers to reduce
repetition and improve errors.

### nat: ParsePortRange, ParsePortRangeToInt: reimplement with parsePortNumber

- Split the implementations from the exported ParsePortRange function.
- The implementation returns an int for ports (instead of an uint64),
  which we cast to the right type in ParsePortRange.
- The parsePortNumber gives more informative errors.


### nat: NewPort: reimplement with parsePortNumber

### nat: ParsePortSpec: reimplement with parsePortNumber

### nat: make Port methods more self-contained

- Use strings.Cut directly instead of using SplitProtoPort
- Use parsePortNumber instead of the SplitProtoPort wrapper


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

