### PR TITLE
nat: SortPortMap: don't require PortMap as argument

### DIFF
--- a/nat/sort.go
+++ b/nat/sort.go
@@ -55,7 +55,7 @@ func (s portMapSorter) Less(i, j int) bool {
 
 // SortPortMap sorts the list of ports and their respected mapping. The ports
 // will explicit HostPort will be placed first.
-func SortPortMap(ports []Port, bindings PortMap) {
+func SortPortMap(ports []Port, bindings map[Port][]PortBinding) {
 	s := portMapSorter{}
 	for _, p := range ports {
 		if binding, ok := bindings[p]; ok && len(binding) > 0 {

--- a/nat/sort_test.go
+++ b/nat/sort_test.go
@@ -50,12 +50,12 @@ func TestSortPortMap(t *testing.T) {
 		"9999/tcp",
 	}
 
-	portMap := PortMap{
-		"22/tcp":   []PortBinding{{}},
-		"8000/tcp": []PortBinding{{}},
-		"8443/tcp": []PortBinding{},
-		"6379/tcp": []PortBinding{{}, {HostIP: "0.0.0.0", HostPort: "32749"}},
-		"9999/tcp": []PortBinding{{HostIP: "0.0.0.0", HostPort: "40000"}},
+	portMap := map[Port][]PortBinding{
+		"22/tcp":   {{}},
+		"8000/tcp": {{}},
+		"8443/tcp": {},
+		"6379/tcp": {{}, {HostIP: "0.0.0.0", HostPort: "32749"}},
+		"9999/tcp": {{HostIP: "0.0.0.0", HostPort: "40000"}},
 	}
 
 	SortPortMap(ports, portMap)
@@ -69,7 +69,7 @@ func TestSortPortMap(t *testing.T) {
 	}) {
 		t.Errorf("failed to prioritize port with explicit mappings, got %v", ports)
 	}
-	if pm := portMap[Port("6379/tcp")]; !reflect.DeepEqual(pm, []PortBinding{
+	if pm := portMap["6379/tcp"]; !reflect.DeepEqual(pm, []PortBinding{
 		{HostIP: "0.0.0.0", HostPort: "32749"},
 		{},
 	}) {


### PR DESCRIPTION
### nat: SortPortMap: don't require PortMap as argument

The `PortMap` type is equivalent to a `map[Port][]PortBinding`, but
the `SortPortMap` only accepted a `PortMap`. Update the signature to
accept either a `PortMap` or a `map[Port][]PortBinding`.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

