### PR TITLE
Deprecate tlsconfig.SystemCertPool

### DIFF
--- a/tlsconfig/certpool.go
+++ b/tlsconfig/certpool.go
@@ -1,16 +1,12 @@
 package tlsconfig
 
-import (
-	"crypto/x509"
-	"runtime"
-)
+import "crypto/x509"
 
-// SystemCertPool returns a copy of the system cert pool,
-// returns an error if failed to load or empty pool on windows.
+// SystemCertPool returns a copy of the system cert pool.
+//
+// Deprecated: use [x509.SystemCertPool] instead.
+//
+//go:fix inline
 func SystemCertPool() (*x509.CertPool, error) {
-	certpool, err := x509.SystemCertPool()
-	if err != nil && runtime.GOOS == "windows" {
-		return x509.NewCertPool(), nil
-	}
-	return certpool, err
+	return x509.SystemCertPool()
 }

--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -84,7 +84,7 @@ func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 	if exclusivePool {
 		pool = x509.NewCertPool()
 	} else {
-		pool, err = SystemCertPool()
+		pool, err = x509.SystemCertPool()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read system certificates: %v", err)
 		}

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -183,9 +183,9 @@ func TestConfigServerTLSClientCASet(t *testing.T) {
 	if tlsConfig.ClientAuth != tls.VerifyClientCertIfGiven {
 		t.Fatal("ClientAuth was not set to what was in the options")
 	}
-	basePool, err := SystemCertPool()
+	basePool, err := x509.SystemCertPool()
 	if err != nil {
-		basePool = x509.NewCertPool()
+		t.Fatal("Failed to get SystemCertPool", err)
 	}
 	// because we are not enabling `ExclusiveRootPools`, any root pool will also contain the system roots
 	if tlsConfig.ClientCAs == nil || len(tlsConfig.ClientCAs.Subjects()) != len(basePool.Subjects())+2 { //nolint:staticcheck // Ignore SA1019: tlsConfig.ClientCAs.Subjects has been deprecated since Go 1.18: if s was returned by SystemCertPool, Subjects will not include the system roots.
@@ -441,9 +441,9 @@ func TestConfigClientTLSRootCAFileWithOneCert(t *testing.T) {
 	if err != nil || tlsConfig == nil {
 		t.Fatal("Unable to configure client TLS", err)
 	}
-	basePool, err := SystemCertPool()
+	basePool, err := x509.SystemCertPool()
 	if err != nil {
-		basePool = x509.NewCertPool()
+		t.Fatal("Failed to get SystemCertPool", err)
 	}
 	// because we are not enabling `ExclusiveRootPools`, any root pool will also contain the system roots
 	if tlsConfig.RootCAs == nil || len(tlsConfig.RootCAs.Subjects()) != len(basePool.Subjects())+2 { //nolint:staticcheck // Ignore SA1019: tlsConfig.ClientCAs.Subjects has been deprecated since Go 1.18: if s was returned by SystemCertPool, Subjects will not include the system roots.


### PR DESCRIPTION
relates to:

- https://github.com/docker/go-connections/pull/21
    - https://github.com/moby/moby/issues/12756
    - https://github.com/moby/moby/issues/15379
- https://github.com/golang/go/commit/3544082f75fd3d2df7af237ed9aef3ddd499ab9c


The wrapper originally existed for historical compatibility reasons that no longer apply:

- 55aadc3cc561 removed the pre-Go-1.7 fallback implementation, leaving the wrapper mainly as a shim around x509.SystemCertPool.
- 3723764c1c59 kept a Windows-specific exception because x509.SystemCertPool on Windows was not yet reliable at the time.
- f652133fef62 and 21876c5afda7 preserved that behavior while the package continued to support older Go versions and older Windows handling.

With current Go versions, x509.SystemCertPool is the correct API on all supported platforms, including Windows, and the old special-case is no longer needed. Keeping a package-local wrapper only adds indirection and retains stale historical behavior and comments.

This change keeps the existing behavior of using the system trust store as the base when building non-exclusive root pools; it only deprecates the local wrapper in favor of the standard library entrypoint.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown changelog
tlsconfig: Deprecate `SystemCertPool`, which is now an alias for [`x509.SystemCertPool`](https://pkg.go.dev/crypto/x509#SystemCertPool) in stdlib.
```

**- A picture of a cute animal (not mandatory but encouraged)**

