### PR TITLE
tlsconfig: add ChaCha20-Poly1305 cipher suites

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -47,6 +47,8 @@ var defaultCipherSuites = []uint16{
 	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 }
 
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/49611#issuecomment-4110588806

### tlsconfig: add ChaCha20-Poly1305 cipher suites

The tlsconfig package provides a curated set of ciphers, with insecure
ciphers removed; originally because Go stdlib included all ciphers by
default (including insecure ones). Current versions of Go provide a much
saner set of defaults, that closely matches the defaults as set in the
tlsconfig package in this module;

- Go 1.8 added ChaCha20-Poly1305 cipher suites
- Go 1.22 removed RSA key-exchange suites from default list
- Go 1.23 removed 3DES suites from default list


| cipher                                        | go-connections       | stdlib defaults    |
|-----------------------------------------------|----------------------|--------------------|
| TLS_RSA_WITH_AES_128_GCM_SHA256               | ✗ (insecure)         | ✗ (since go1.22)   |
| TLS_RSA_WITH_AES_256_GCM_SHA384               | ✗ (insecure)         | ✗ (since go1.22)   |
| TLS_RSA_WITH_AES_128_CBC_SHA                  | ✗ (insecure)         | ✗ (since go1.22)   |
| TLS_RSA_WITH_AES_256_CBC_SHA                  | ✗ (insecure)         | ✗ (since go1.22)   |
| TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA           | ✗ (insecure)         | ✗ (since go1.23)   |
| TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA          | ✗ (legacy, non-AEAD) | ✓                  |
| TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA          | ✗ (legacy, non-AEAD) | ✓                  |
| TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA            | ✗ (legacy, non-AEAD) | ✓                  |
| TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA            | ✗ (legacy, non-AEAD) | ✓                  |
| TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256       | ✓                    | ✓                  |
| TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384       | ✓                    | ✓                  |
| TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256         | ✓                    | ✓                  |
| TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384         | ✓                    | ✓                  |
| TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   | ✗                    | ✓ (added in go1.8) |
| TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 | ✗                    | ✓ (added in go1.8) |

From the above table, differences are;

- Go still includes legacy, non-AEAD (TLS 1.2 CBC suites); these are still considered safe,
  but superseded by AEAD ciphers (AES-GCM, ChaCha20) and mainly retained for compatibility.
- Go 1.8 and up added ChaCha20-Poly1305 cipher suites (see https://go-review.googlesource.com/c/go/+/30958).

This patch adds the ChaCha20-Poly1305 cipher suites to align closer with the
set of cipher suites provided by default in Go stdlib.

Note that this only impacts TLS 1.2 (and older, but we don't allow TLS 1.1);
for TLS 1.3, Go does not allow overriding the list of supported ciphers.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown changelog
tlsconfig: add ChaCha20-Poly1305 cipher suites
```


**- A picture of a cute animal (not mandatory but encouraged)**

