### PR TITLE
tlsconfig: make root pool tests deterministic across platforms

### DIFF
--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -34,6 +34,9 @@ type Options struct {
 	// the system pool will be used.
 	ExclusiveRootPools bool
 	MinVersion         uint16
+
+	// systemCertPool allows mocking the system cert-pool for testing.
+	systemCertPool func() (*x509.CertPool, error)
 }
 
 // DefaultServerAcceptedCiphers should be uses by code which already has a crypto/tls
@@ -86,7 +89,11 @@ func certPool(opts Options) (*x509.CertPool, error) {
 	if opts.ExclusiveRootPools {
 		pool = x509.NewCertPool()
 	} else {
-		pool, err = x509.SystemCertPool()
+		if opts.systemCertPool != nil {
+			pool, err = opts.systemCertPool()
+		} else {
+			pool, err = x509.SystemCertPool()
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read system certificates: %v", err)
 		}

--- a/tlsconfig/config.go
+++ b/tlsconfig/config.go
@@ -77,13 +77,13 @@ func defaultConfig(ops ...func(*tls.Config)) *tls.Config {
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.
-func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
+func certPool(opts Options) (*x509.CertPool, error) {
 	// If we should verify the server, we need to load a trusted ca
 	var (
 		pool *x509.CertPool
 		err  error
 	)
-	if exclusivePool {
+	if opts.ExclusiveRootPools {
 		pool = x509.NewCertPool()
 	} else {
 		pool, err = x509.SystemCertPool()
@@ -91,12 +91,15 @@ func certPool(caFile string, exclusivePool bool) (*x509.CertPool, error) {
 			return nil, fmt.Errorf("failed to read system certificates: %v", err)
 		}
 	}
-	pemData, err := os.ReadFile(caFile)
+	if opts.CAFile == "" {
+		return pool, nil
+	}
+	pemData, err := os.ReadFile(opts.CAFile)
 	if err != nil {
-		return nil, fmt.Errorf("could not read CA certificate %q: %v", caFile, err)
+		return nil, fmt.Errorf("could not read CA certificate %q: %v", opts.CAFile, err)
 	}
 	if !pool.AppendCertsFromPEM(pemData) {
-		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", caFile)
+		return nil, fmt.Errorf("failed to append certificates from PEM file: %q", opts.CAFile)
 	}
 	return pool, nil
 }
@@ -199,7 +202,7 @@ func Client(options Options) (*tls.Config, error) {
 	tlsConfig := defaultConfig()
 	tlsConfig.InsecureSkipVerify = options.InsecureSkipVerify
 	if !options.InsecureSkipVerify && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
+		CAs, err := certPool(options)
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +235,7 @@ func Server(options Options) (*tls.Config, error) {
 	}
 	tlsConfig.Certificates = []tls.Certificate{tlsCert}
 	if options.ClientAuth >= tls.VerifyClientCertIfGiven && options.CAFile != "" {
-		CAs, err := certPool(options.CAFile, options.ExclusiveRootPools)
+		CAs, err := certPool(options)
 		if err != nil {
 			return nil, err
 		}

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -118,8 +118,8 @@ func TestConfigServerTLSServerCertsOnly(t *testing.T) {
 	if len(tlsConfig.Certificates[0].Certificate) != len(keypair.Certificate) {
 		t.Fatal("Unexpected server certificates")
 	}
-	for i, cert := range tlsConfig.Certificates[0].Certificate {
-		if !bytes.Equal(cert, keypair.Certificate[i]) {
+	for i, crt := range tlsConfig.Certificates[0].Certificate {
+		if !bytes.Equal(crt, keypair.Certificate[i]) {
 			t.Fatal("Unexpected server certificates")
 		}
 	}
@@ -214,11 +214,11 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		if pemBlock == nil {
 			t.Fatal("Malformed certificate")
 		}
-		cert, err := x509.ParseCertificate(pemBlock.Bytes)
+		crt, err := x509.ParseCertificate(pemBlock.Bytes)
 		if err != nil {
 			t.Fatal("Unable to parse certificate")
 		}
-		testCerts = append(testCerts, cert)
+		testCerts = append(testCerts, crt)
 	}
 
 	// ExclusiveRootPools not set, so should be able to verify both system-signed certs
@@ -234,8 +234,8 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		t.Fatal("Unable to configure server TLS", err)
 	}
 
-	for i, cert := range testCerts {
-		if _, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs}); err != nil {
+	for i, crt := range testCerts {
+		if _, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs}); err != nil {
 			t.Fatalf("Unable to verify certificate %d: %v", i, err)
 		}
 	}
@@ -254,13 +254,13 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		t.Fatal("Unable to configure server TLS", err)
 	}
 
-	for i, cert := range testCerts {
-		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
+	for i, crt := range testCerts {
+		_, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
 		switch {
 		case i == 0 && err != nil:
 			t.Fatal("Unable to verify custom certificate, even though the root pool should have only the custom CA", err)
 		case i == 1 && err == nil:
-			t.Fatal("Successfully verified system root-signed certificate though the root pool should have only the cusotm CA", err)
+			t.Fatal("Successfully verified system root-signed certificate though the root pool should have only the custom CA", err)
 		}
 	}
 
@@ -274,8 +274,8 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		t.Fatal("Unable to configure server TLS", err)
 	}
 
-	for i, cert := range testCerts {
-		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
+	for i, crt := range testCerts {
+		_, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
 		switch {
 		case i == 1 && err != nil:
 			t.Fatal("Unable to verify system root-signed certificate, even though the root pool should be the system pool only", err)
@@ -510,8 +510,8 @@ func TestConfigClientTLSValidClientCertAndKey(t *testing.T) {
 	if len(tlsConfig.Certificates[0].Certificate) != len(keypair.Certificate) {
 		t.Fatal("Unexpected client certificates")
 	}
-	for i, cert := range tlsConfig.Certificates[0].Certificate {
-		if !bytes.Equal(cert, keypair.Certificate[i]) {
+	for i, crt := range tlsConfig.Certificates[0].Certificate {
+		if !bytes.Equal(crt, keypair.Certificate[i]) {
 			t.Fatal("Unexpected client certificates")
 		}
 	}
@@ -556,11 +556,11 @@ func TestConfigClientExclusiveRootPools(t *testing.T) {
 		if pemBlock == nil {
 			t.Fatal("Malformed certificate")
 		}
-		cert, err := x509.ParseCertificate(pemBlock.Bytes)
+		crt, err := x509.ParseCertificate(pemBlock.Bytes)
 		if err != nil {
 			t.Fatal("Unable to parse certificate")
 		}
-		testCerts = append(testCerts, cert)
+		testCerts = append(testCerts, crt)
 	}
 
 	// ExclusiveRootPools not set, so should be able to verify both system-signed certs
@@ -571,8 +571,8 @@ func TestConfigClientExclusiveRootPools(t *testing.T) {
 		t.Fatal("Unable to configure client TLS", err)
 	}
 
-	for i, cert := range testCerts {
-		if _, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs}); err != nil {
+	for i, crt := range testCerts {
+		if _, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs}); err != nil {
 			t.Fatalf("Unable to verify certificate %d: %v", i, err)
 		}
 	}
@@ -588,13 +588,13 @@ func TestConfigClientExclusiveRootPools(t *testing.T) {
 		t.Fatal("Unable to configure client TLS", err)
 	}
 
-	for i, cert := range testCerts {
-		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
+	for i, crt := range testCerts {
+		_, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
 		switch {
 		case i == 0 && err != nil:
 			t.Fatal("Unable to verify custom certificate, even though the root pool should have only the custom CA", err)
 		case i == 1 && err == nil:
-			t.Fatal("Successfully verified system root-signed certificate though the root pool should have only the cusotm CA", err)
+			t.Fatal("Successfully verified system root-signed certificate though the root pool should have only the custom CA", err)
 		}
 	}
 
@@ -605,8 +605,8 @@ func TestConfigClientExclusiveRootPools(t *testing.T) {
 		t.Fatal("Unable to configure client TLS", err)
 	}
 
-	for i, cert := range testCerts {
-		_, err := cert.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
+	for i, crt := range testCerts {
+		_, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
 		switch {
 		case i == 1 && err != nil:
 			t.Fatal("Unable to verify system root-signed certificate, even though the root pool should be the system pool only", err)

--- a/tlsconfig/config_test.go
+++ b/tlsconfig/config_test.go
@@ -4,41 +4,14 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 )
 
-// This is the currently active Amazon Root CA 1 (CN=Amazon Root CA 1,O=Amazon,C=US),
-// downloaded from: https://www.amazontrust.com/repository/AmazonRootCA1.pem
-// It's valid since May 26 00:00:00 2015 GMT and expires on Jan 17 00:00:00 2038 GMT.
-// Download updated versions from https://www.amazontrust.com/repository/
 const (
-	systemRootTrustedCert = `
------BEGIN CERTIFICATE-----
-MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
-ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
-b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL
-MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv
-b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj
-ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM
-9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw
-IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6
-VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L
-93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm
-jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC
-AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA
-A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI
-U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs
-N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv
-o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU
-5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy
-rqXRfboQnoZsG4q5WTP468SQvvG5
------END CERTIFICATE-----
-`
 	rsaPrivateKeyFile             = "fixtures/key.pem"
 	certificateFile               = "fixtures/cert.pem"
 	multiCertificateFile          = "fixtures/multi.pem"
@@ -195,31 +168,29 @@ func TestConfigServerTLSClientCASet(t *testing.T) {
 
 // Exclusive root pools determines whether the CA pool will be a union of the system
 // certificate pool and custom certs, or an exclusive or of the custom certs and system pool
+//
+// NOTE: In reality this behavior depends on the platform trust store and would
+// be best validated via integration tests. Here we inject a fake system pool so
+// the unit test can deterministically verify the intended semantics.
 func TestConfigServerExclusiveRootPools(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		// FIXME: see https://github.com/docker/go-connections/issues/105.
-		t.Skip("FIXME: failing on Windows and darwin")
-	}
 	key, cert := getCertAndKey()
-	ca := getMultiCert()
 
-	caBytes, err := os.ReadFile(ca)
+	customRoot, err := newTestTrustRoot()
 	if err != nil {
-		t.Fatal("Unable to read CA certs", err)
+		t.Fatal("Unable to generate fake custom CA", err)
 	}
 
-	var testCerts []*x509.Certificate
-	for _, pemBytes := range [][]byte{caBytes, []byte(systemRootTrustedCert)} {
-		pemBlock, _ := pem.Decode(pemBytes)
-		if pemBlock == nil {
-			t.Fatal("Malformed certificate")
-		}
-		crt, err := x509.ParseCertificate(pemBlock.Bytes)
-		if err != nil {
-			t.Fatal("Unable to parse certificate")
-		}
-		testCerts = append(testCerts, crt)
+	ca := filepath.Join(t.TempDir(), "custom-ca.pem")
+	if err := os.WriteFile(ca, customRoot.RootPEM, 0o644); err != nil {
+		t.Fatal("Unable to write custom CA file", err)
 	}
+
+	systemLeaf, err := systemRootTrustedX509()
+	if err != nil {
+		t.Fatal("Unable to load fake system certificate", err)
+	}
+
+	testCerts := []*x509.Certificate{customRoot.LeafCert, systemLeaf}
 
 	// ExclusiveRootPools not set, so should be able to verify both system-signed certs
 	// and custom CA-signed certs
@@ -228,6 +199,8 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		KeyFile:    key,
 		ClientAuth: tls.VerifyClientCertIfGiven,
 		CAFile:     ca,
+
+		systemCertPool: fakeSystemCertPool(),
 	})
 
 	if err != nil || tlsConfig == nil {
@@ -248,6 +221,7 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		ClientAuth:         tls.VerifyClientCertIfGiven,
 		CAFile:             ca,
 		ExclusiveRootPools: true,
+		systemCertPool:     fakeSystemCertPool(),
 	})
 
 	if err != nil || tlsConfig == nil {
@@ -264,24 +238,19 @@ func TestConfigServerExclusiveRootPools(t *testing.T) {
 		}
 	}
 
-	// No CA file provided, system cert should be verifiable only
+	// No CA file provided means the server does not configure ClientCAs.
 	tlsConfig, err = Server(Options{
 		CertFile: cert,
 		KeyFile:  key,
+
+		systemCertPool: fakeSystemCertPool(),
 	})
 
 	if err != nil || tlsConfig == nil {
 		t.Fatal("Unable to configure server TLS", err)
 	}
-
-	for i, crt := range testCerts {
-		_, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.ClientCAs})
-		switch {
-		case i == 1 && err != nil:
-			t.Fatal("Unable to verify system root-signed certificate, even though the root pool should be the system pool only", err)
-		case i == 0 && err == nil:
-			t.Fatal("Successfully verified custom certificate though the root pool should be the system pool only", err)
-		}
+	if tlsConfig.ClientCAs != nil {
+		t.Fatal("Expected ClientCAs to be nil when no CA file is provided")
 	}
 }
 
@@ -538,34 +507,36 @@ func TestConfigClientTLSEncryptedKey(t *testing.T) {
 
 // Exclusive root pools determines whether the CA pool will be a union of the system
 // certificate pool and custom certs, or an exclusive or of the custom certs and system pool
+//
+// NOTE: In reality this behavior depends on the platform trust store and would
+// be best validated via integration tests. Here we inject a fake system pool so
+// the unit test can deterministically verify the intended semantics.
 func TestConfigClientExclusiveRootPools(t *testing.T) {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		// FIXME: see https://github.com/docker/go-connections/issues/105.
-		t.Skip("FIXME: failing on Windows and darwin")
-	}
-	ca := getMultiCert()
+	key, cert := getCertAndKey()
 
-	caBytes, err := os.ReadFile(ca)
+	customRoot, err := newTestTrustRoot()
 	if err != nil {
-		t.Fatal("Unable to read CA certs", err)
+		t.Fatal("Unable to generate fake custom CA", err)
 	}
 
-	var testCerts []*x509.Certificate
-	for _, pemBytes := range [][]byte{caBytes, []byte(systemRootTrustedCert)} {
-		pemBlock, _ := pem.Decode(pemBytes)
-		if pemBlock == nil {
-			t.Fatal("Malformed certificate")
-		}
-		crt, err := x509.ParseCertificate(pemBlock.Bytes)
-		if err != nil {
-			t.Fatal("Unable to parse certificate")
-		}
-		testCerts = append(testCerts, crt)
+	ca := filepath.Join(t.TempDir(), "custom-ca.pem")
+	if err := os.WriteFile(ca, customRoot.RootPEM, 0o644); err != nil {
+		t.Fatal("Unable to write custom CA file", err)
 	}
+
+	systemLeaf, err := systemRootTrustedX509()
+	if err != nil {
+		t.Fatal("Unable to load fake system certificate", err)
+	}
+
+	testCerts := []*x509.Certificate{customRoot.LeafCert, systemLeaf}
 
 	// ExclusiveRootPools not set, so should be able to verify both system-signed certs
 	// and custom CA-signed certs
-	tlsConfig, err := Client(Options{CAFile: ca})
+	tlsConfig, err := Client(Options{
+		CAFile:         ca,
+		systemCertPool: fakeSystemCertPool(),
+	})
 
 	if err != nil || tlsConfig == nil {
 		t.Fatal("Unable to configure client TLS", err)
@@ -582,6 +553,7 @@ func TestConfigClientExclusiveRootPools(t *testing.T) {
 	tlsConfig, err = Client(Options{
 		CAFile:             ca,
 		ExclusiveRootPools: true,
+		systemCertPool:     fakeSystemCertPool(),
 	})
 
 	if err != nil || tlsConfig == nil {
@@ -598,21 +570,18 @@ func TestConfigClientExclusiveRootPools(t *testing.T) {
 		}
 	}
 
-	// No CA file provided, system cert should be verifiable only
-	tlsConfig, err = Client(Options{})
+	// No CA file provided means the client leaves RootCAs unset.
+	tlsConfig, err = Client(Options{
+		CertFile:       cert,
+		KeyFile:        key,
+		systemCertPool: fakeSystemCertPool(),
+	})
 
 	if err != nil || tlsConfig == nil {
 		t.Fatal("Unable to configure client TLS", err)
 	}
-
-	for i, crt := range testCerts {
-		_, err := crt.Verify(x509.VerifyOptions{Roots: tlsConfig.RootCAs})
-		switch {
-		case i == 1 && err != nil:
-			t.Fatal("Unable to verify system root-signed certificate, even though the root pool should be the system pool only", err)
-		case i == 0 && err == nil:
-			t.Fatal("Successfully verified custom certificate though the root pool should be the system pool only", err)
-		}
+	if tlsConfig.RootCAs != nil {
+		t.Fatal("Expected RootCAs to be nil when no CA file is provided")
 	}
 }
 

--- a/tlsconfig/systempool_test.go
+++ b/tlsconfig/systempool_test.go
@@ -1,0 +1,146 @@
+// These helpers provide a deterministic replacement for x509.SystemCertPool
+// in tests.
+//
+// On macOS and Windows, crypto/x509 may delegate certificate verification to
+// platform APIs, and the system pool is not a simple in-memory set of roots.
+// As a result, tests that rely on SystemCertPool can exhibit OS-dependent
+// behavior.
+//
+// To avoid this, tests inject a synthetic "system" pool backed by generated
+// certificates. This ensures consistent behavior across platforms and allows
+// precise control over trusted roots when testing root-pool composition logic.
+package tlsconfig
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"sync"
+	"time"
+)
+
+type testTrustRoot struct {
+	RootPEM  []byte            // PEM-encoded fake root CA.
+	RootCert *x509.Certificate // Parsed fake root CA.
+	Pool     *x509.CertPool    // Pool containing RootCert.
+	LeafPEM  []byte            // PEM-encoded cert signed by RootCert.
+	LeafCert *x509.Certificate // Parsed cert trusted by the fake root.
+}
+
+func newTestTrustRoot() (*testTrustRoot, error) {
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	rootSerial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	rootTemplate := &x509.Certificate{
+		SerialNumber: rootSerial,
+		Subject: pkix.Name{
+			CommonName:   "fake system root",
+			Organization: []string{"tlsconfig tests"},
+		},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.AddDate(10, 0, 0),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, err
+	}
+
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		return nil, err
+	}
+
+	rootPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: rootDER,
+	})
+
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(rootPEM); !ok {
+		return nil, errors.New("failed to append fake root")
+	}
+
+	leafKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	leafSerial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	leafTemplate := &x509.Certificate{
+		SerialNumber: leafSerial,
+		Subject: pkix.Name{
+			CommonName: "fake system leaf",
+		},
+		NotBefore:   now.Add(-time.Hour),
+		NotAfter:    now.AddDate(1, 0, 0),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"localhost"},
+	}
+
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootCert, &leafKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, err
+	}
+
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		return nil, err
+	}
+
+	leafPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: leafDER,
+	})
+
+	return &testTrustRoot{
+		RootPEM:  rootPEM,
+		RootCert: rootCert,
+		Pool:     pool,
+		LeafPEM:  leafPEM,
+		LeafCert: leafCert,
+	}, nil
+}
+
+var fakeSystemRootData = sync.OnceValues(func() (*testTrustRoot, error) {
+	return newTestTrustRoot()
+})
+
+func systemRootTrustedX509() (*x509.Certificate, error) {
+	root, err := fakeSystemRootData()
+	if err != nil {
+		return nil, err
+	}
+	return root.LeafCert, nil
+}
+
+func fakeSystemCertPool() func() (*x509.CertPool, error) {
+	return func() (*x509.CertPool, error) {
+		root, err := fakeSystemRootData()
+		if err != nil {
+			return nil, err
+		}
+		return root.Pool.Clone(), nil
+	}
+}


### PR DESCRIPTION
- [x] stacked on https://github.com/docker/go-connections/pull/150
- [x] stacked on https://github.com/docker/go-connections/pull/152
- fixes https://github.com/docker/go-connections/issues/105

### tlsconfig: make root pool tests deterministic across platforms

The existing tests relied on x509.SystemCertPool behaving as a
regular in-memory cert pool. This assumption only holds on Linux;
on macOS and Windows the pool delegates to platform APIs, leading
to non-deterministic behavior and test failures.

Refactor tests to:
- inject a fake "system" cert pool backed by generated test roots
- verify leaf certificates instead of root certificates
- avoid reliance on host trust stores

This makes the tests portable and deterministic while still
validating the intended semantics of ExclusiveRootPools.

Note: real system pool behavior remains platform-dependent and
would ideally be covered by integration tests.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

