### PR TITLE
sockets: remove double error decoration

### DIFF
--- a/sockets/unix_socket_windows.go
+++ b/sockets/unix_socket_windows.go
@@ -48,7 +48,7 @@ func WithAdditionalUsersAndGroups(additionalUsersAndGroups []string) SockOption 
 		}
 		sd, err := getSecurityDescriptor(additionalUsersAndGroups...)
 		if err != nil {
-			return fmt.Errorf("looking up SID: %w", err)
+			return err
 		}
 		return withSDDL(sd)(path)
 	}


### PR DESCRIPTION
The error was already decorated in getSecurityDescriptor with the same prefix.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

