### PR TITLE
sockets: set socket permissions without umask hack

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -62,11 +62,6 @@ type SockOption func(string) error
 
 // NewUnixSocketWithOpts creates a Unix socket with the specified options.
 //
-// This function temporarily changes the system's "umask" to 0777 to work around
-// a race condition between creating the socket and setting its permissions. While
-// this should only be for a short duration, it may affect other processes that
-// create files/directories during that period.
-//
 // On Unix platforms, socket permissions are 0000 by default, i.e. no access
 // for anyone. Pass WithChmod() and WithChown() to set the desired permissions
 // and ownership.
@@ -99,19 +94,7 @@ func NewUnixSocketWithOpts(path string, opts ...SockOption) (net.Listener, error
 		return nil, err
 	}
 
-	l, err := listenUnix(path)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, op := range opts {
-		if err := op(path); err != nil {
-			_ = l.Close()
-			return nil, err
-		}
-	}
-
-	return l, nil
+	return listenUnix(path, opts...)
 }
 
 // isAbstractSocket reports whether path is an abstract Unix socket address.

--- a/sockets/unix_socket_linux.go
+++ b/sockets/unix_socket_linux.go
@@ -1,0 +1,25 @@
+package sockets
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// maxListenerBacklog returns the maximum length of the queue of pending
+// connections for a listening socket.
+//
+// It is similar to in stdlib, but without the fallbacks for Kernel < 4.1.0;
+// https://github.com/golang/go/blob/go1.26.3/src/net/sock_linux.go#L33-L53
+func maxListenerBacklog() int {
+	b, err := os.ReadFile("/proc/sys/net/core/somaxconn")
+	if err != nil {
+		return syscall.SOMAXCONN
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || n <= 0 {
+		return syscall.SOMAXCONN
+	}
+	return n
+}

--- a/sockets/unix_socket_nolinux.go
+++ b/sockets/unix_socket_nolinux.go
@@ -1,0 +1,39 @@
+//go:build !linux && !windows
+
+package sockets
+
+import (
+	"runtime"
+	"syscall"
+)
+
+// maxListenerBacklog is similar to the equivalent in stdlib;
+// https://github.com/golang/go/blob/go1.26.3/src/net/sock_bsd.go#L14-L39
+func maxListenerBacklog() int {
+	var (
+		n   uint32
+		err error
+	)
+	switch runtime.GOOS {
+	case "darwin", "ios":
+		n, err = syscall.SysctlUint32("kern.ipc.somaxconn")
+	case "freebsd":
+		n, err = syscall.SysctlUint32("kern.ipc.soacceptqueue")
+	case "netbsd":
+		// NOTE: NetBSD has no somaxconn-like kernel state so far
+	case "openbsd":
+		n, err = syscall.SysctlUint32("kern.somaxconn")
+	default:
+		return syscall.SOMAXCONN
+	}
+	if n == 0 || err != nil {
+		return syscall.SOMAXCONN
+	}
+	// FreeBSD stores the backlog in a uint16, as does Linux.
+	// Assume the other BSDs do too. Truncate number to avoid wrapping.
+	// See issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return int(n)
+}

--- a/sockets/unix_socket_unix.go
+++ b/sockets/unix_socket_unix.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 	"syscall"
 )
 
@@ -121,7 +122,7 @@ func listenUnix(path string, opts ...SockOption) (_ net.Listener, retErr error) 
 		}
 	}
 
-	if err := syscall.Listen(fd, syscall.SOMAXCONN); err != nil {
+	if err := syscall.Listen(fd, listenerBacklog()); err != nil {
 		return nil, os.NewSyscallError("listen", err)
 	}
 
@@ -143,3 +144,6 @@ func listenUnix(path string, opts ...SockOption) (_ net.Listener, retErr error) 
 
 	return l, nil
 }
+
+// listenerBacklog is a caching wrapper around maxListenerBacklog.
+var listenerBacklog = sync.OnceValue(maxListenerBacklog)

--- a/sockets/unix_socket_unix.go
+++ b/sockets/unix_socket_unix.go
@@ -10,6 +10,13 @@ import (
 	"syscall"
 )
 
+// defaultSocketPerms is the default permission mode applied to newly created
+// Unix sockets. Sockets are created inaccessible by default; callers can
+// override this by passing [WithChmod].
+//
+// TODO(thaJeztah): Consider changing the default to 0o600, making the socket usable by its owner by default.
+const defaultSocketPerms os.FileMode = 0o000
+
 // WithChown modifies the socket file's uid and gid.
 //
 // Abstract Unix sockets have no filesystem representation, so this option
@@ -62,22 +69,77 @@ func NewUnixSocket(path string, gid int) (net.Listener, error) {
 	return NewUnixSocketWithOpts(path, WithChown(0, gid), WithChmod(0o660))
 }
 
-func listenUnix(path string) (net.Listener, error) {
-	// net.Listen does not allow for permissions to be set. As a result, when
-	// specifying custom permissions ("WithChmod()"), there is a short time
-	// between creating the socket and applying the permissions, during which
-	// the socket permissions are Less restrictive than desired.
+func listenUnix(path string, opts ...SockOption) (_ net.Listener, retErr error) {
+	// net.Listen does not allow permissions or ownership to be set between
+	// bind(2), which creates the socket path, and listen(2), which makes it
+	// possible for clients to connect.
 	//
-	// To work around this limitation of net.Listen(), we temporarily set the
-	// umask to 0777, which forces the socket to be created with 000 permissions
-	// (i.e.: no access for anyone). After that, WithChmod() must be used to set
-	// the desired permissions.
+	// Creating the socket manually lets us apply options after bind(2), but
+	// before listen(2). This avoids temporarily relaxing the process umask while
+	// still preventing a socket from becoming connectable before the requested
+	// permissions are applied.
 	//
-	// We don't use "defer" here, to reset the umask to its original value as soon
-	// as possible. Ideally we'd be able to detect if WithChmod() was passed as
-	// an option, and skip changing umask if default permissions are used.
-	origUmask := syscall.Umask(0o777)
-	l, err := net.Listen("unix", path)
-	syscall.Umask(origUmask)
-	return l, err
+	// See https://github.com/golang/go/issues/11822
+
+	// Similar to sysSocket in stdlib, but without the fast path for Linux.
+	// https://github.com/golang/go/blob/go1.26.3/src/net/sys_cloexec.go#L18-L36
+	syscall.ForkLock.RLock()
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err == nil {
+		syscall.CloseOnExec(fd) // No syscall.SOCK_CLOEXEC on macOS.
+	}
+	syscall.ForkLock.RUnlock()
+	if err != nil {
+		return nil, os.NewSyscallError("socket", err)
+	}
+
+	defer func() {
+		if fd >= 0 {
+			_ = syscall.Close(fd)
+		}
+	}()
+
+	if err := syscall.Bind(fd, &syscall.SockaddrUnix{Name: path}); err != nil {
+		return nil, os.NewSyscallError("bind", err)
+	}
+
+	defer func() {
+		if retErr != nil {
+			_ = syscall.Unlink(path)
+		}
+	}()
+
+	// Secure by default: the socket is not accessible at all
+	// unless permission options are set through WithChmod.
+	if err := os.Chmod(path, defaultSocketPerms); err != nil {
+		return nil, err
+	}
+
+	for _, op := range opts {
+		if err := op(path); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := syscall.Listen(fd, syscall.SOMAXCONN); err != nil {
+		return nil, os.NewSyscallError("listen", err)
+	}
+
+	f := os.NewFile(uintptr(fd), "unix:"+path)
+	fd = -1 // f now owns the original fd; prevent the defer from closing it.
+
+	// FileListener duplicates f, sets the duplicate close-on-exec and nonblocking,
+	// and returns a net.Listener backed by that duplicate. The temporary *os.File
+	// is no longer needed after this point.
+	l, err := net.FileListener(f)
+	_ = f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	if ul, ok := l.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(true)
+	}
+
+	return l, nil
 }

--- a/sockets/unix_socket_windows.go
+++ b/sockets/unix_socket_windows.go
@@ -85,7 +85,7 @@ func withSDDL(sddl string) SockOption {
 	}
 }
 
-// NewUnixSocket creates a new unix socket.
+// NewUnixSocket creates a new Unix socket.
 //
 // It sets [BasePermissions] on the socket path and grants the given additional
 // users and groups to generic read (GR) and write (GW) access. It returns
@@ -128,6 +128,16 @@ func getSecurityDescriptor(additionalUsersAndGroups ...string) (string, error) {
 	return sddl, nil
 }
 
-func listenUnix(path string) (net.Listener, error) {
-	return net.Listen("unix", path)
+func listenUnix(path string, opts ...SockOption) (net.Listener, error) {
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	for _, op := range opts {
+		if err := op(path); err != nil {
+			_ = l.Close()
+			return nil, err
+		}
+	}
+	return l, nil
 }


### PR DESCRIPTION
- [x] stacked on https://github.com/docker/go-connections/pull/159
- [x] stacked on https://github.com/docker/go-connections/pull/162

relates to:

- https://github.com/moby/moby/pull/5947
- https://github.com/docker/go-connections/pull/75
- https://github.com/golang/go/issues/11822


Create Unix sockets manually to apply permissions and ownership after bind(2), but before listen(2), avoiding races in net.Listen and removing the need for temporary process-wide umask changes.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

