### PR TITLE
sockets: test-enhancements and improve coverage

### DIFF
--- a/sockets/unix_socket_test.go
+++ b/sockets/unix_socket_test.go
@@ -3,8 +3,36 @@ package sockets
 import (
 	"fmt"
 	"net"
+	"os"
 	"testing"
 )
+
+// Use the macOS limit (104 bytes), which is lower than Linux's 108-byte
+// limit, so tests pass on both platforms.
+const maxSocketPathLen = 104
+
+// tempSocketPath returns a temporary socket path short enough to avoid
+// exceeding Unix-domain socket path length limits on some platforms.
+func tempSocketPath(t *testing.T) string {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "test*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	path := f.Name()
+	t.Cleanup(func() { _ = os.Remove(path) })
+	if len(path) >= maxSocketPathLen {
+		t.Fatalf("temporary socket path too long (%d >= %d): %q", len(path), maxSocketPathLen, path)
+	}
+	// Remove the temporary file; we only need a unique path / name.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
 
 func runTest(t *testing.T, path string, l net.Listener, echoStr string) {
 	go func() {

--- a/sockets/unix_socket_test.go
+++ b/sockets/unix_socket_test.go
@@ -58,3 +58,27 @@ func runTest(t *testing.T, path string, l net.Listener, echoStr string) {
 		t.Fatal(fmt.Errorf("msg may lost"))
 	}
 }
+
+// TestNewUnixSocketWithOptsRemovesExistingFile verifies that a pre-existing
+// regular file is removed before creating the socket.
+func TestNewUnixSocketWithOptsRemovesExistingFile(t *testing.T) {
+	socketPath := tempSocketPath(t)
+
+	if err := os.WriteFile(socketPath, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	l, err := NewUnixSocketWithOpts(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = l.Close() }()
+
+	info, err := os.Lstat(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("expected %q to be a socket, got mode %v", socketPath, info.Mode())
+	}
+}

--- a/sockets/unix_socket_unix_test.go
+++ b/sockets/unix_socket_unix_test.go
@@ -3,6 +3,7 @@
 package sockets
 
 import (
+	"errors"
 	"os"
 	"syscall"
 	"testing"
@@ -54,6 +55,26 @@ func TestUnixSocketWithOptsDefaultPermissions(t *testing.T) {
 	const wantPerms os.FileMode = 0o000
 	if got := info.Mode().Perm(); got != wantPerms {
 		t.Fatalf("unexpected file permissions: expected: %#o, got: %#o", wantPerms, got)
+	}
+}
+
+// TestUnixSocketWithOptsCleanupOnError verifies that partially initialized
+// sockets are cleaned up when a socket option returns an error.
+func TestUnixSocketWithOptsCleanupOnError(t *testing.T) {
+	socketPath := tempSocketPath(t)
+
+	wantErr := errors.New("boom")
+	_, err := NewUnixSocketWithOpts(socketPath, func(string) error {
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+
+	if _, err := os.Lstat(socketPath); err == nil {
+		t.Fatalf("socket %q still exists", socketPath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected error stating %q: %v", socketPath, err)
 	}
 }
 

--- a/sockets/unix_socket_unix_test.go
+++ b/sockets/unix_socket_unix_test.go
@@ -9,20 +9,15 @@ import (
 )
 
 func TestUnixSocketWithOpts(t *testing.T) {
-	socketFile, err := os.CreateTemp("", "test*.sock")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = socketFile.Close()
-	defer func() { _ = os.Remove(socketFile.Name()) }()
+	socketPath := tempSocketPath(t)
 
 	uid, gid := os.Getuid(), os.Getgid()
 	perms := os.FileMode(0660)
-	l, err := NewUnixSocketWithOpts(socketFile.Name(), WithChown(uid, gid), WithChmod(perms))
+	l, err := NewUnixSocketWithOpts(socketPath, WithChown(uid, gid), WithChmod(perms))
 	if err != nil {
 		t.Fatal(err)
 	}
-	p, err := os.Stat(socketFile.Name())
+	p, err := os.Stat(socketPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +33,7 @@ func TestUnixSocketWithOpts(t *testing.T) {
 	defer func() { _ = l.Close() }()
 
 	echoStr := "hello"
-	runTest(t, socketFile.Name(), l, echoStr)
+	runTest(t, socketPath, l, echoStr)
 }
 
 // TestNewUnixSocket run under root user.
@@ -47,12 +42,12 @@ func TestNewUnixSocket(t *testing.T) {
 		t.Skip("requires root")
 	}
 	gid := os.Getgid()
-	path := "/tmp/test.sock"
+	socketPath := tempSocketPath(t)
 	echoStr := "hello"
-	l, err := NewUnixSocket(path, gid)
+	l, err := NewUnixSocket(socketPath, gid)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = l.Close() }()
-	runTest(t, path, l, echoStr)
+	runTest(t, socketPath, l, echoStr)
 }

--- a/sockets/unix_socket_unix_test.go
+++ b/sockets/unix_socket_unix_test.go
@@ -36,6 +36,27 @@ func TestUnixSocketWithOpts(t *testing.T) {
 	runTest(t, socketPath, l, echoStr)
 }
 
+// TestUnixSocketWithOptsDefaultPermissions verifies that sockets created
+// without an explicit WithChmod option have permissions set to 0000.
+func TestUnixSocketWithOptsDefaultPermissions(t *testing.T) {
+	socketPath := tempSocketPath(t)
+	l, err := NewUnixSocketWithOpts(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = l.Close() }()
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const wantPerms os.FileMode = 0o000
+	if got := info.Mode().Perm(); got != wantPerms {
+		t.Fatalf("unexpected file permissions: expected: %#o, got: %#o", wantPerms, got)
+	}
+}
+
 // TestNewUnixSocket run under root user.
 func TestNewUnixSocket(t *testing.T) {
 	if os.Getuid() != 0 {

--- a/sockets/unix_socket_windows_test.go
+++ b/sockets/unix_socket_windows_test.go
@@ -61,27 +61,20 @@ func TestGetSecurityDescriptor(t *testing.T) {
 }
 
 func TestUnixSocketWithOpts(t *testing.T) {
-	socketFile, err := os.CreateTemp("", "test*.sock")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = socketFile.Close()
-	defer func() { _ = os.Remove(socketFile.Name()) }()
-
-	l, err := NewUnixSocketWithOpts(socketFile.Name())
+	socketPath := tempSocketPath(t)
+	l, err := NewUnixSocketWithOpts(socketPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = l.Close() }()
 
 	echoStr := "hello"
-	runTest(t, socketFile.Name(), l, echoStr)
+	runTest(t, socketPath, l, echoStr)
 }
 
 func TestNewUnixSocket(t *testing.T) {
 	group := "Users" // for testing, should always be available
 	socketPath := filepath.Join(os.TempDir(), "test.sock")
-	defer func() { _ = os.Remove(socketPath) }()
 	t.Logf("socketPath: %s, path length: %d", socketPath, len(socketPath))
 
 	l, err := NewUnixSocket(socketPath, []string{group})
@@ -96,7 +89,6 @@ func TestNewUnixSocketUnknownGroup(t *testing.T) {
 	group := "NoSuchUserOrGroup"
 	socketPath := filepath.Join(os.TempDir(), "fail.sock")
 	_, err := NewUnixSocket(socketPath, []string{group})
-	_ = os.Remove(socketPath)
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}


### PR DESCRIPTION
### sockets: add helper for socket-paths

We can't use `t.TempDir()` for this, as that may reach the
maximum socket path length (on macOS), resulting in obscure
errors (bind: invalid argument).


### sockets: add test for default socket permissions

### sockets: add test to verify socket is cleaned up on failure

### sockets: add test for cleanup of pre-existing socket path

NewUnixSocketWithOpts cleans up pre-existing sockets
(syscall.Unlink); test that it works correctly.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

