### PR TITLE
sockets: InmemSocket: add DialContext

### DIFF
--- a/sockets/inmem_socket.go
+++ b/sockets/inmem_socket.go
@@ -6,17 +6,14 @@ import (
 	"sync"
 )
 
-// dummyAddr is used to satisfy net.Addr for the in-mem socket
-// it is just stored as a string and returns the string for all calls
-type dummyAddr string
+// inmemAddr is used to satisfy net.Addr for the in-memory socket.
+type inmemAddr string
 
 // Network returns the addr string, satisfies net.Addr
-func (a dummyAddr) Network() string {
-	return string(a)
-}
+func (a inmemAddr) Network() string { return "inmem" }
 
 // String returns the string form
-func (a dummyAddr) String() string {
+func (a inmemAddr) String() string {
 	return string(a)
 }
 
@@ -24,7 +21,7 @@ func (a dummyAddr) String() string {
 type InmemSocket struct {
 	chConn  chan net.Conn
 	chClose chan struct{}
-	addr    dummyAddr
+	addr    inmemAddr
 	mu      sync.Mutex
 }
 
@@ -35,7 +32,7 @@ func NewInmemSocket(addr string, bufSize int) *InmemSocket {
 	return &InmemSocket{
 		chConn:  make(chan net.Conn, bufSize),
 		chClose: make(chan struct{}),
-		addr:    dummyAddr(addr),
+		addr:    inmemAddr(addr),
 	}
 }
 

--- a/sockets/inmem_socket.go
+++ b/sockets/inmem_socket.go
@@ -73,9 +73,10 @@ func (s *InmemSocket) Dial(network, addr string) (net.Conn, error) {
 	srvConn, clientConn := net.Pipe()
 	select {
 	case s.chConn <- srvConn:
+		return clientConn, nil
 	case <-s.chClose:
+		_ = srvConn.Close()
+		_ = clientConn.Close()
 		return nil, net.ErrClosed
 	}
-
-	return clientConn, nil
 }

--- a/sockets/inmem_socket.go
+++ b/sockets/inmem_socket.go
@@ -1,6 +1,7 @@
 package sockets
 
 import (
+	"context"
 	"net"
 	"sync"
 )
@@ -67,13 +68,38 @@ func (s *InmemSocket) Close() error {
 	return nil
 }
 
-// Dial is used to establish a connection with the in-mem server.
-// It returns a [net.ErrClosed] if the connection is already closed.
+// Dial establishes a connection with the in-memory listener.
+//
+// The network and addr parameters are accepted for compatibility with
+// conventional dialer APIs but are currently ignored.
+//
+// It is equivalent to calling DialContext with context.Background().
+// It returns [net.ErrClosed] if the listener has already been closed.
 func (s *InmemSocket) Dial(network, addr string) (net.Conn, error) {
+	return s.DialContext(context.Background(), network, addr)
+}
+
+// DialContext establishes a connection with the in-memory listener.
+//
+// The network and addr parameters are accepted for compatibility with
+// conventional dialer APIs but are currently ignored.
+//
+// If ctx is canceled before the connection is established, DialContext
+// returns the context error. It returns [net.ErrClosed] if the listener
+// has already been closed.
+func (s *InmemSocket) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	srvConn, clientConn := net.Pipe()
 	select {
 	case s.chConn <- srvConn:
 		return clientConn, nil
+	case <-ctx.Done():
+		_ = srvConn.Close()
+		_ = clientConn.Close()
+		return nil, ctx.Err()
 	case <-s.chClose:
 		_ = srvConn.Close()
 		_ = clientConn.Close()


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/52898#discussion_r3644267930

### sockets: InmemSocket: close net.Pipe on failed dial

If the listener is closed after net.Pipe() is created but before the
server side is handed to Accept(), both ends of the pipe are abandoned.

Close both connections before returning net.ErrClosed to avoid leaking
the unused pipe resources.


### sockets: InmemSocket: add DialContext

Add DialContext to support canceling a pending in-memory connection while
waiting for the listener to accept it.

Also close both ends of an abandoned net.Pipe when dialing fails because
the listener has been closed or the context is canceled.

Keep Dial for compatibility by delegating to DialContext with
context.Background().

### sockets: InmemSocket: tweak inmemAddr

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
sockets: InmemSocket: add DialContext
```


**- A picture of a cute animal (not mandatory but encouraged)**

