### PR TITLE
sockets: fix some remaining TODOs in Windows code

### DIFF
--- a/sockets/unix_socket_windows.go
+++ b/sockets/unix_socket_windows.go
@@ -103,23 +103,24 @@ func NewUnixSocket(path string, additionalUsersAndGroups []string) (net.Listener
 
 // getSecurityDescriptor returns the DACL for the Unix socket.
 //
-// By default, it grants [BasePermissions], but allows for additional
-// users and groups to get generic read (GR) and write (GW) access. It
-// returns an error when failing to resolve any of the additional users
-// and groups.
+// By default, it grants [BasePermissions]. Additional users and groups
+// are granted generic read (GR) and write (GW) access. It returns an
+// error if any name cannot be resolved to a SID.
 func getSecurityDescriptor(additionalUsersAndGroups ...string) (string, error) {
 	sddl := BasePermissions
 
 	// Grant generic read (GR) and write (GW) access to whatever
 	// additional users or groups were specified.
 	//
-	// TODO(thaJeztah): should we fail on, or remove duplicates?
+	// We keep duplicates; two identical allow ACEs are redundant,
+	// but they do not create conflicting permissions, so should not error.
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/20233ed8-a6c6-4097-aafa-dd545ed24428
 	for _, g := range additionalUsersAndGroups {
 		sid, err := winio.LookupSidByName(strings.TrimSpace(g))
 		if err != nil {
 			return "", fmt.Errorf("looking up SID: %w", err)
 		}
-		sddl += fmt.Sprintf("(A;;GRGW;;;%s)", sid)
+		sddl += "(A;;GRGW;;;" + sid + ")"
 	}
 	return sddl, nil
 }

--- a/sockets/unix_socket_windows_test.go
+++ b/sockets/unix_socket_windows_test.go
@@ -4,13 +4,37 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
+
+// wellKnownAccountName returns the localized account name for a well-known SID.
+//
+// Windows defines many built-in users and groups by stable well-known SIDs
+// (for example, WinBuiltinUsersSid == S-1-5-32-545), but their display names
+// are localized (for example, "Users" on English systems). This helper
+// constructs the well-known SID and resolves it to the local account name so
+// tests do not depend on the installation language.
+func wellKnownAccountName(t *testing.T, sidType windows.WELL_KNOWN_SID_TYPE) string {
+	t.Helper()
+
+	sid, err := windows.CreateWellKnownSid(sidType)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	account, _, _, err := sid.LookupAccount("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return account
+}
 
 func TestGetSecurityDescriptor(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		sddl, err := getSecurityDescriptor()
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 		expected := BasePermissions
 		if sddl != expected {
@@ -18,26 +42,32 @@ func TestGetSecurityDescriptor(t *testing.T) {
 		}
 	})
 	t.Run("Users", func(t *testing.T) {
-		const name = "Users" // for testing, should always be available
+		name := wellKnownAccountName(t, windows.WinBuiltinUsersSid)
 		sddl, err := getSecurityDescriptor(name)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
-		// FIXME(thaJeztah): this may not be a reproducible SID; probably should do some fuzzy matching.
+
+		// S-1-5-32-545 is the well-known SID for the built-in Users group.
+		// https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
 		const expected = "D:P(A;;GA;;;BA)(A;;GA;;;SY)(A;;GRGW;;;S-1-5-32-545)"
 		if sddl != expected {
 			t.Errorf("expected: %s, got: %s", expected, sddl)
 		}
 	})
 
-	// TODO(thaJeztah): should this fail on duplicate users?
+	// Two identical allow ACEs are redundant, but they do not create
+	// conflicting permissions, so should not error.
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/20233ed8-a6c6-4097-aafa-dd545ed24428
 	t.Run("Users twice", func(t *testing.T) {
-		const name = "Users" // for testing, should always be available
+		name := wellKnownAccountName(t, windows.WinBuiltinUsersSid)
 		sddl, err := getSecurityDescriptor(name, name)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
-		// FIXME(thaJeztah): this may not be a reproducible SID; probably should do some fuzzy matching.
+
+		// S-1-5-32-545 is the well-known SID for the built-in Users group.
+		// https://learn.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
 		const expected = "D:P(A;;GA;;;BA)(A;;GA;;;SY)(A;;GRGW;;;S-1-5-32-545)(A;;GRGW;;;S-1-5-32-545)"
 		if sddl != expected {
 			t.Errorf("expected: %s, got: %s", expected, sddl)
@@ -50,7 +80,7 @@ func TestGetSecurityDescriptor(t *testing.T) {
 			t.Errorf("expected an empty sddl, got: %s", sddl)
 		}
 		if err == nil {
-			t.Error("expected error")
+			t.Fatal("expected error")
 		}
 
 		const expected = "looking up SID: lookup account NoSuchUserOrGroup: not found"
@@ -73,7 +103,7 @@ func TestUnixSocketWithOpts(t *testing.T) {
 }
 
 func TestNewUnixSocket(t *testing.T) {
-	group := "Users" // for testing, should always be available
+	group := wellKnownAccountName(t, windows.WinBuiltinUsersSid)
 	socketPath := filepath.Join(os.TempDir(), "test.sock")
 	t.Logf("socketPath: %s, path length: %d", socketPath, len(socketPath))
 
@@ -86,7 +116,7 @@ func TestNewUnixSocket(t *testing.T) {
 }
 
 func TestNewUnixSocketUnknownGroup(t *testing.T) {
-	group := "NoSuchUserOrGroup"
+	const group = "NoSuchUserOrGroup" // non-existing user or group
 	socketPath := filepath.Join(os.TempDir(), "fail.sock")
 	_, err := NewUnixSocket(socketPath, []string{group})
 	if err == nil {


### PR DESCRIPTION
Use the well-known Users SID to resolve the localized account name instead of assuming the built-in Users group is named "Users". The tests continue to assert against the canonical SID in the expected SDDL, making them language-independent while keeping the expected values explicit.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

