### PR TITLE
sockets: improve abstract Unix socket handling

### DIFF
--- a/sockets/unix_socket.go
+++ b/sockets/unix_socket.go
@@ -47,23 +47,54 @@ For example:
 package sockets
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
+	"runtime"
 	"syscall"
 )
+
+const supportsAbstractSockets = runtime.GOOS == "linux"
 
 // SockOption sets up socket file's creating option
 type SockOption func(string) error
 
-// NewUnixSocketWithOpts creates a unix socket with the specified options.
-// By default, socket permissions are 0000 (i.e.: no access for anyone); pass
-// WithChmod() and WithChown() to set the desired ownership and permissions.
+// NewUnixSocketWithOpts creates a Unix socket with the specified options.
 //
 // This function temporarily changes the system's "umask" to 0777 to work around
 // a race condition between creating the socket and setting its permissions. While
 // this should only be for a short duration, it may affect other processes that
 // create files/directories during that period.
+//
+// On Unix platforms, socket permissions are 0000 by default, i.e. no access
+// for anyone. Pass WithChmod() and WithChown() to set the desired permissions
+// and ownership.
+//
+// On Windows, the socket uses Windows ACLs. Pass WithBasePermissions() to allow
+// Administrators and LocalSystem full access, or WithAdditionalUsersAndGroups()
+// to also grant generic read and write access to additional users or groups.
+//
+// Abstract Unix sockets (Go's Linux-specific "@" shorthand and the native
+// leading-NUL representation) are supported only on Linux. On other platforms,
+// attempts to use abstract socket addresses return an error. Because abstract
+// sockets have no filesystem representation, filesystem-specific socket
+// options are not supported.
+//
+// On platforms without abstract Unix socket support, attempts to use abstract
+// socket addresses return an error wrapping [errors.ErrUnsupported].
 func NewUnixSocketWithOpts(path string, opts ...SockOption) (net.Listener, error) {
+	if isAbstractSocket(path) {
+		if !supportsAbstractSockets {
+			return nil, fmt.Errorf("abstract Unix socket %q is not supported on %s: %w", path, runtime.GOOS, errors.ErrUnsupported)
+		}
+		for _, opt := range opts {
+			if err := opt(path); err != nil {
+				return nil, err
+			}
+		}
+		return net.Listen("unix", path)
+	}
 	if err := syscall.Unlink(path); err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -81,4 +112,21 @@ func NewUnixSocketWithOpts(path string, opts ...SockOption) (net.Listener, error
 	}
 
 	return l, nil
+}
+
+// isAbstractSocket reports whether path is an abstract Unix socket address.
+//
+// Go recognizes two representations of abstract socket addresses:
+//
+//   - On Linux, a path beginning with '@' is translated by the standard library
+//     to the kernel's native leading-NUL representation.
+//     See https://pkg.go.dev/net@go1.27rc2#UnixAddr.
+//
+//   - A path beginning with a NUL byte uses the kernel's native representation
+//     directly. See https://github.com/golang/go/issues/78615.
+//
+// The interpretation of these addresses is platform-dependent; this helper only
+// recognizes the syntax.
+func isAbstractSocket(path string) bool {
+	return len(path) > 0 && (path[0] == '@' || path[0] == 0)
 }

--- a/sockets/unix_socket_unix.go
+++ b/sockets/unix_socket_unix.go
@@ -3,14 +3,27 @@
 package sockets
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"syscall"
 )
 
-// WithChown modifies the socket file's uid and gid
+// WithChown modifies the socket file's uid and gid.
+//
+// Abstract Unix sockets have no filesystem representation, so this option
+// returns an error wrapping [errors.ErrUnsupported] when used with an abstract
+// socket.
 func WithChown(uid, gid int) SockOption {
 	return func(path string) error {
+		if isAbstractSocket(path) {
+			return &os.PathError{
+				Op:   "chown",
+				Path: path,
+				Err:  fmt.Errorf("abstract Unix sockets do not support filesystem permissions: %w", errors.ErrUnsupported),
+			}
+		}
 		if err := os.Chown(path, uid, gid); err != nil {
 			return err
 		}
@@ -19,8 +32,19 @@ func WithChown(uid, gid int) SockOption {
 }
 
 // WithChmod modifies socket file's access mode.
+//
+// Abstract Unix sockets have no filesystem representation, so this option
+// returns an error wrapping [errors.ErrUnsupported] when used with an abstract
+// socket.
 func WithChmod(mask os.FileMode) SockOption {
 	return func(path string) error {
+		if isAbstractSocket(path) {
+			return &os.PathError{
+				Op:   "chmod",
+				Path: path,
+				Err:  fmt.Errorf("abstract Unix sockets do not support filesystem permissions: %w", errors.ErrUnsupported),
+			}
+		}
 		if err := os.Chmod(path, mask); err != nil {
 			return err
 		}
@@ -28,7 +52,12 @@ func WithChmod(mask os.FileMode) SockOption {
 	}
 }
 
-// NewUnixSocket creates a unix socket with the specified path and group.
+// NewUnixSocket creates a Unix socket with the specified path and group.
+//
+// On Unix platforms, the socket is owned by root:gid and has permissions 0660.
+//
+// Abstract Unix sockets are not supported by this helper. Use [NewUnixSocketWithOpts]
+// without filesystem permission options instead.
 func NewUnixSocket(path string, gid int) (net.Listener, error) {
 	return NewUnixSocketWithOpts(path, WithChown(0, gid), WithChmod(0o660))
 }

--- a/sockets/unix_socket_unix_test.go
+++ b/sockets/unix_socket_unix_test.go
@@ -5,6 +5,7 @@ package sockets
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 )
@@ -92,4 +93,86 @@ func TestNewUnixSocket(t *testing.T) {
 	}
 	defer func() { _ = l.Close() }()
 	runTest(t, socketPath, l, echoStr)
+}
+
+// TestNewUnixSocketWithOptsAbstract verifies that abstract Unix sockets behave
+// correctly. Unlike filesystem-backed sockets, they must not create a socket
+// file before or after the listener is closed.
+func TestNewUnixSocketWithOptsAbstract(t *testing.T) {
+	// Go documents "@" as a Linux-specific shorthand for abstract Unix sockets:
+	//
+	//   "On Linux, a Name beginning with '@' denotes an abstract socket address:
+	//    the '@' is translated to a NUL byte when the address is passed to the
+	//    kernel..."
+	//
+	// See https://pkg.go.dev/net@go1.27rc2#UnixAddr.
+	//
+	// Linux also accepts the native kernel representation (a leading NUL byte),
+	// so both forms are tested here. See https://github.com/golang/go/issues/78615.
+	prefixes := []struct{ name, prefix string }{
+		{name: "at_prefix", prefix: "@"},
+		{name: "nul_prefix", prefix: "\x00"},
+	}
+
+	tests := []struct {
+		name string
+		opts []SockOption
+	}{
+		{
+			name: "no_options",
+		},
+		{
+			name: "chmod",
+			opts: []SockOption{
+				WithChmod(0o660),
+			},
+		},
+		{
+			name: "chown",
+			opts: []SockOption{
+				WithChown(os.Getuid(), os.Getgid()),
+			},
+		},
+	}
+
+	for _, prefix := range prefixes {
+		t.Run(prefix.name, func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					socketPath := prefix.prefix + filepath.Base(tempSocketPath(t))
+
+					l, err := NewUnixSocketWithOpts(socketPath, tc.opts...)
+					wantErr := !supportsAbstractSockets || len(tc.opts) > 0
+					if wantErr {
+						if err == nil {
+							_ = l.Close()
+							t.Fatalf("expected abstract socket %q to be rejected", socketPath)
+						}
+						if !errors.Is(err, errors.ErrUnsupported) {
+							t.Fatalf("expected unsupported error, got %v", err)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if prefix.prefix != "\x00" { // can't stat NUL-prefixed paths.
+						if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+							t.Fatalf("expected no filesystem entry for abstract socket %q, got %v", socketPath, err)
+						}
+					}
+
+					runTest(t, socketPath, l, "hello")
+					if err := l.Close(); err != nil {
+						t.Fatal(err)
+					}
+					if prefix.prefix != "\x00" { // can't stat NUL-prefixed paths.
+						if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+							t.Fatalf("expected no filesystem entry after Close() for abstract socket %q, got %v", socketPath, err)
+						}
+					}
+				})
+			}
+		})
+	}
 }

--- a/sockets/unix_socket_windows.go
+++ b/sockets/unix_socket_windows.go
@@ -91,6 +91,9 @@ func withSDDL(sddl string) SockOption {
 // users and groups to generic read (GR) and write (GW) access. It returns
 // an error when failing to resolve any of the additional users and groups,
 // or when failing to apply the ACL.
+//
+// Abstract Unix sockets are not supported by this helper. Attempts to use
+// abstract socket addresses return an error wrapping [errors.ErrUnsupported].
 func NewUnixSocket(path string, additionalUsersAndGroups []string) (net.Listener, error) {
 	var opts []SockOption
 	if len(additionalUsersAndGroups) > 0 {

--- a/sockets/unix_socket_windows_test.go
+++ b/sockets/unix_socket_windows_test.go
@@ -1,6 +1,9 @@
 package sockets
 
 import (
+	"errors"
+	"os/user"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/sys/windows"
@@ -110,6 +113,70 @@ func TestNewUnixSocket(t *testing.T) {
 	}
 	defer func() { _ = l.Close() }()
 	runTest(t, socketPath, l, "hello")
+}
+
+// TestNewUnixSocketWithOptsAbstract verifies that abstract Unix sockets behave
+// correctly. Unlike filesystem-backed sockets, they must not create a socket
+// file before or after the listener is closed.
+func TestNewUnixSocketWithOptsAbstract(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Go documents "@" as a Linux-specific shorthand for abstract Unix sockets:
+	//
+	//   "On Linux, a Name beginning with '@' denotes an abstract socket address:
+	//    the '@' is translated to a NUL byte when the address is passed to the
+	//    kernel..."
+	//
+	// See https://pkg.go.dev/net@go1.27rc2#UnixAddr.
+	//
+	// Windows uses the native kernel representation (a leading NUL byte) for
+	// abstract Unix sockets. Both forms are tested here to document Go's
+	// platform-specific behavior.
+	prefixes := []struct{ name, prefix string }{
+		{name: "at_prefix", prefix: "@"},
+		{name: "nul_prefix", prefix: "\x00"},
+	}
+	tests := []struct {
+		name string
+		opts []SockOption
+	}{
+		{
+			name: "no options",
+		},
+		{
+			name: "base permissions",
+			opts: []SockOption{
+				WithBasePermissions(),
+			},
+		},
+		{
+			name: "additional users and groups",
+			opts: []SockOption{
+				WithAdditionalUsersAndGroups([]string{currentUser.Username}),
+			},
+		},
+	}
+
+	for _, prefix := range prefixes {
+		t.Run(prefix.name, func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					socketPath := prefix.prefix + filepath.Base(tempSocketPath(t))
+					l, err := NewUnixSocketWithOpts(socketPath, tc.opts...)
+					if err == nil {
+						_ = l.Close()
+						t.Fatalf("expected abstract socket %q to be rejected", socketPath)
+					}
+					if !errors.Is(err, errors.ErrUnsupported) {
+						t.Fatalf("expected unsupported error, got %v", err)
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestNewUnixSocketUnknownGroup(t *testing.T) {


### PR DESCRIPTION
sockets: improve abstract Unix socket handling

Improve handling of abstract Unix socket addresses across platforms.

On Linux, abstract sockets are supported but do not have a filesystem
representation, so filesystem-specific operations such as unlinking an
existing socket or applying ownership and permissions are skipped or
rejected as appropriate.

On platforms without abstract socket support, attempts to create an
abstract socket now fail with a clear unsupported error instead of
falling through to platform-specific failures.

Add regression tests covering abstract socket behavior, including both
Go's Linux-specific "@" shorthand and the native leading-NUL
representation. The tests verify the expected behavior on supported and
unsupported platforms and guard against regressions in permission
handling.

The new tests verify that abstract sockets:

- can be created and used like regular Unix sockets;
- do not create a filesystem entry while the listener is active; and
- do not leave a filesystem entry behind after the listener is closed.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

