### PR TITLE
sockets: Restore compatibility with Unix-like platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,44 @@ jobs:
         run: go build ./...
       - name: Test
         run: ${{ matrix.test-cmd }}
+
+  cross-build:
+    name: Cross-build supported operating systems
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: "go.mod"
+      - name: Build
+        run: |
+          packages=()
+          while IFS= read -r package; do
+            if [ -n "$package" ]; then
+              packages+=("$package")
+            fi
+          done < <(go list -f '{{if ne .Name "main"}}{{.ImportPath}}{{end}}' ./...)
+
+          operating_systems=(
+            android
+            darwin
+            dragonfly
+            freebsd
+            illumos
+            ios
+            linux
+            netbsd
+            openbsd
+            solaris
+            windows
+          )
+
+          for operating_system in "${operating_systems[@]}"; do
+            echo "Building $operating_system"
+            CGO_ENABLED=0 GOOS="$operating_system" go build "${packages[@]}"
+          done

--- a/sockets/unix_socket_bsd.go
+++ b/sockets/unix_socket_bsd.go
@@ -1,0 +1,37 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+
+package sockets
+
+import (
+	"runtime"
+	"syscall"
+)
+
+// maxListenerBacklog is similar to the equivalent in stdlib;
+// https://github.com/golang/go/blob/go1.26.3/src/net/sock_bsd.go#L14-L39
+func maxListenerBacklog() int {
+	var (
+		n   uint32
+		err error
+	)
+	switch runtime.GOOS {
+	case "darwin", "ios":
+		n, err = syscall.SysctlUint32("kern.ipc.somaxconn")
+	case "freebsd":
+		n, err = syscall.SysctlUint32("kern.ipc.soacceptqueue")
+	case "netbsd":
+		// NOTE: NetBSD has no somaxconn-like kernel state so far
+	case "openbsd":
+		n, err = syscall.SysctlUint32("kern.somaxconn")
+	}
+	if n == 0 || err != nil {
+		return syscall.SOMAXCONN
+	}
+	// FreeBSD stores the backlog in a uint16, as does Linux.
+	// Assume the other BSDs do too. Truncate number to avoid wrapping.
+	// See issue 5030.
+	if n > 1<<16-1 {
+		n = 1<<16 - 1
+	}
+	return int(n)
+}

--- a/sockets/unix_socket_nolinux.go
+++ b/sockets/unix_socket_nolinux.go
@@ -1,39 +1,9 @@
-//go:build !linux && !windows
+//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !windows
 
 package sockets
 
-import (
-	"runtime"
-	"syscall"
-)
+import "syscall"
 
-// maxListenerBacklog is similar to the equivalent in stdlib;
-// https://github.com/golang/go/blob/go1.26.3/src/net/sock_bsd.go#L14-L39
 func maxListenerBacklog() int {
-	var (
-		n   uint32
-		err error
-	)
-	switch runtime.GOOS {
-	case "darwin", "ios":
-		n, err = syscall.SysctlUint32("kern.ipc.somaxconn")
-	case "freebsd":
-		n, err = syscall.SysctlUint32("kern.ipc.soacceptqueue")
-	case "netbsd":
-		// NOTE: NetBSD has no somaxconn-like kernel state so far
-	case "openbsd":
-		n, err = syscall.SysctlUint32("kern.somaxconn")
-	default:
-		return syscall.SOMAXCONN
-	}
-	if n == 0 || err != nil {
-		return syscall.SOMAXCONN
-	}
-	// FreeBSD stores the backlog in a uint16, as does Linux.
-	// Assume the other BSDs do too. Truncate number to avoid wrapping.
-	// See issue 5030.
-	if n > 1<<16-1 {
-		n = 1<<16 - 1
-	}
-	return int(n)
+	return syscall.SOMAXCONN
 }


### PR DESCRIPTION
- fix: https://github.com/docker/go-connections/issues/164

The non-Linux backlog implementation used `syscall.SysctlUint32`, which is only available on BSD systems. This prevented Illumos and other Unix-like systems from compiling even though they should use the portable fallback.

Limit dynamic backlog detection to BSD systems and use `syscall.SOMAXCONN` elsewhere.
Cross-build supported operating systems in CI to catch similar platform-specific symbol errors.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

